### PR TITLE
Update copyright statement and resolve contradiction

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 BSD 3-Clause License
 --------------------
 
-Copyright 2020–2024, Contributors to rcsbsearchapi
+Copyright 2024 rcsbsearchapi Contributors
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
The license file has some noticeable weirdness:

- It says `All rights reserved`, which is incompatible with the BSD 3-Clause License.
- Lists Spencer Bliven as the copyright holder. Additional authors and affiliated organizations likely hold the copyright.
- Completely unimportant, but significant changes were made post-2020.

I'm an outsider, but I don't think review by all authors is needed here.
Maybe @sbliven and @piehld (plus anyone who wants to) can review?