### PR TITLE
Change SchemaGroup to act as dict and documentation edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,21 +44,23 @@ You can also check whether an attribute exists for a given structure by using th
 
 Refer to the [Search Attributes](https://search.rcsb.org/structure-search-attributes.html) and [Chemical Attributes](https://search.rcsb.org/chemical-search-attributes.html) documentation for a full list of attributes and applicable operators.
 
-To search an attribute, you can make an AttributeQuery.
+To search an attribute, you can make an `AttributeQuery`.
 ```python
 from rcsbsearchapi import AttributeQuery
 
 # Construct the query
 query = AttributeQuery(
     attribute="rcsb_entity_source_organism.scientific_name",
-    operator="exact_match",  # other operators include "contains phrase" and "exists"
+    operator="exact_match",  # other operators include "contains_phrase" and "exists"
     value="Homo sapiens"
 )
 results = list(query())  # construct a list from query results
 print(results)
 ```
 
-When using certain operators such as `exact_match`, `greater`, or `less`, you can also use `rcsb_attributes` (imported below as `attrs`).
+You can also use `rcsb_attributes` (imported below as `attrs`) to create `AttributeQuery`s.
+
+When using certain operators such as `exact_match`, `greater`, or `less`, you can use Python operators like `==`, `>`, or `<`.
 
 Using this syntax, attribute names can be tab-completed. 
 
@@ -78,8 +80,8 @@ You can combine multiple queries using Python bitwise operators.
 |&       |AND                     |
 |\|      |OR                      |
 |~       |NOT                     |
+|^       |XOR/symmetric difference|
 |-       |set difference          |
-|^       |symmetric difference/XOR|
 
 ```python
 from rcsbsearchapi import rcsb_attributes as attrs

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 [![PyPi Release](https://img.shields.io/pypi/v/rcsbsearchapi.svg)](https://pypi.org/project/rcsbsearchapi/)
 [![Build Status](https://dev.azure.com/rcsb/RCSB%20PDB%20Python%20Projects/_apis/build/status/rcsb.py-rcsbsearchapi?branchName=master)](https://dev.azure.com/rcsb/RCSB%20PDB%20Python%20Projects/_build/latest?definitionId=39&branchName=master)
 [![Documentation Status](https://readthedocs.org/projects/rcsbsearchapi/badge/?version=latest)](https://rcsbsearchapi.readthedocs.io/en/latest/?badge=latest)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/rcsb/py-rcsbsearchapi/master)
+<a href="https://colab.research.google.com/github/rcsb/py-rcsbsearchapi/blob/master/notebooks/quickstart.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
 
 # rcsbsearchapi
 
 Python interface for the RCSB PDB Search API.
 
 This package requires Python 3.7 or later.
+
+# Quickstart
 
 ## Installation
 
@@ -18,536 +19,94 @@ Get it from PyPI:
 
 Or, download from [GitHub](https://github.com/rcsb/py-rcsbsearchapi)
 
-## Examples
+## Getting Started
+Full documentation available at [readthedocs](https://rcsbsearchapi.readthedocs.io/en/latest/index.html)
 
-Here is a quick example of how the package is used. Two syntaxes are available for
-constructing queries: an "operator" API using python's comparators, and a "fluent"
-syntax where terms are chained together. Which to use is a matter of preference.
-Below, you will find examples of Full text and attribute search and sequence search.
-
-A runnable jupyter notebook with this example is available in [notebooks/quickstart.ipynb](notebooks/quickstart.ipynb), or can be run online using binder:
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/rcsb/py-rcsbsearchapi/master?labpath=notebooks%2Fquickstart.ipynb)
-
-An additional example including a Covid-19 related example is in [notebooks/covid.ipynb](notebooks/covid.ipynb):
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/rcsb/py-rcsbsearchapi/master?labpath=notebooks%2Fcovid.ipynb)
-
-### Operator Example
-
-Here is an example from the [RCSB PDB Search
-API](http://search.rcsb.org/#search-example-1) page, using the operator syntax. This
-query finds symmetric dimers having a twofold rotation with the DNA-binding domain of
-a heat-shock transcription factor. Full text and attribute search is used.
+To perform a general search for structures associated with the phrase "Hemoglobin", you can create a TextQuery. This does a "full-text" search, which is a general search on text associated with PDB structures or molecular definitions. Learn more about available search services on the [RCSB PDB Search API docs](https://search.rcsb.org/#search-services).
 ```python
-from rcsbsearchapi.search import TextQuery
-from rcsbsearchapi import rcsb_attributes as attrs
+from rcsbsearchapi import TextQuery
 
-# Create terminals for each query
-q1 = TextQuery('"heat-shock transcription factor"')
-q2 = attrs.rcsb_struct_symmetry.symbol == "C2"
-q3 = attrs.rcsb_struct_symmetry.kind == "Global Symmetry"
-q4 = attrs.rcsb_entry_info.polymer_entity_count_DNA >= 1
+# Search for structures associated with the phrase "Hemoglobin"
+query = TextQuery(value="Hemoglobin")
 
-# combined using bitwise operators (&, |, ~, etc)
-query = q1 & (q2 & q3 & q4)
+# Execute the query by running it as a function
+results = query()
 
-# Call the query to execute it
-for assemblyid in query("assembly"):
-    print(assemblyid)
-```
-For a full list of attributes, please refer to the [RCSB PDB
-schema](http://search.rcsb.org/rcsbsearch/v2/metadata/schema).
-
-### Fluent Example
-
-Here is the same example using the
-[fluent](https://en.wikipedia.org/wiki/Fluent_interface) syntax.
-```python
-from rcsbsearchapi.search import TextQuery, AttributeQuery, Attr
-
-# Start with a Attr or TextQuery, then add terms
-results = TextQuery("heat-shock transcription factor").and_(
-    # Add attribute node as fully-formed AttributeQuery
-    AttributeQuery(attribute="rcsb_struct_symmetry.symbol", operator="exact_match", value="C2") \
-    # Add attribute node as Attr with chained operations
-    .and_(Attr("rcsb_struct_symmetry.kind")).exact_match("Global Symmetry") \
-    # Add attribute node by name (converted to Attr) with chained operations
-    .and_("rcsb_entry_info.polymer_entity_count_DNA").greater_or_equal(1)
-    ).exec("assembly")
-
-# Exec produces an iterator of IDs
-for assemblyid in results:
-    print(assemblyid)
-```
-### Structural Attribute Search and Chemical Attribute Search Combination
-
-Grouping of a Structural Attribute query and Chemical Attribute query is permitted as long as grouping is done correctly and search services are specified accordingly. Note the example below. More details on attributes that are available for text searches can be found on the [RCSB PDB Search API](https://search.rcsb.org/#search-attributes) page.
-```python
-from rcsbsearchapi.const import CHEMICAL_ATTRIBUTE_SEARCH_SERVICE, STRUCTURE_ATTRIBUTE_SEARCH_SERVICE
-from rcsbsearchapi.search import AttributeQuery
-
-# By default, service is set to "text" for structural attribute search
-q1 = AttributeQuery("exptl.method", "exact_match", "electron microscopy",
-                    STRUCTURE_ATTRIBUTE_SEARCH_SERVICE # this constant specifies "text" service
-                    )
-
-# Need to specify chemical attribute search service - "text_chem"
-q2 = AttributeQuery("drugbank_info.brand_names", "contains_phrase", "tylenol",
-                    CHEMICAL_ATTRIBUTE_SEARCH_SERVICE # this constant specifies "text_chem" service
-                    )
-
-query = q1 & q2 # combining queries
-
-list(query())
-```
-### Computed Structure Models
-
-The [RCSB PDB Search API](https://search.rcsb.org/#results_content_type) page provides information on how to include Computed Structure Models (CSMs) into a search query. Here is a code example below. This query returns IDs for experimental and computed structure models associated with "hemoglobin". Queries for *only* computed models or *only* experimental models can also be made (default).
-```python
-from rcsbsearchapi.search import TextQuery
-
-q1 = TextQuery("hemoglobin")
-
-# add parameter as a list with either "computational" or "experimental" or both as list values
-q2 = q1(return_content_type=["computational", "experimental"])
-
-list(q2)
-```
-### Return Types and Attribute Search
-
-A search query can return different result types when a return type is specified. 
-Below are examples on specifying return types Polymer Entities,
-Non-polymer Entities, Polymer Instances, and Molecular Definitions, using a Structure Attribute query. 
-More information on return types can be found in the 
-[RCSB PDB Search API](https://search.rcsb.org/#building-search-request) page.
-```python
-from rcsbsearchapi.search import AttributeQuery
-
-q1 = AttributeQuery("rcsb_entry_container_identifiers.entry_id", "in", ["4HHB"]) # query for 4HHB deoxyhemoglobin
-
-# Polymer entities
-for poly in q1("polymer_entity"): # include return type as a string parameter for query object
-    print(poly)
-    
-# Non-polymer entities
-for nonPoly in q1("non_polymer_entity"):
-    print(nonPoly)
-    
-# Polymer instances
-for polyInst in q1("polymer_instance"):
-    print(polyInst)
-    
-# Molecular definitions
-for mol in q1("mol_definition"):
-    print(mol)
-```
-### Counting Results
-
-If only the number of results is desired, the count function can be used. This query returns the number of experimental models associated with "hemoglobin".
-```python
-from rcsbsearchapi.search import TextQuery
-
-q1 = TextQuery("hemoglobin")
-
-# N.B., Just as shown above for `query()`, `return_type` and `return_content_type` can also be specified as parameters to `count()`
-q1.count()
-```
-### Obtaining Scores for Results
-
-Results can be returned alongside additional metadata, including result scores. To return this metadata, set the `results_verbosity` parameter to "verbose" (all metadata), "minimal" (scores only), or "compact" (default, no metadata). If set to "verbose" or "minimal", results will be returned as a list of dictionaries. For example, here we get all experimental models associated with "hemoglobin", along with their scores.
-```python
-from rcsbsearchapi.search import TextQuery
-
-q1 = TextQuery("hemoglobin")
-for idscore in list(q1(results_verbosity="minimal")):
-    print(idscore)
-```
-### Protein Sequence Search Example
-
-Below is an example from the [RCSB PDB Search API](https://search.rcsb.org/#search-example-3) page,
-using the sequence search function.
-This query finds macromolecular PDB entities that share 90% sequence identity with
-GTPase HRas protein from *Gallus gallus* (*Chicken*).
-```python
-from rcsbsearchapi.search import SequenceQuery
-
-# Use SequenceQuery class and add parameters
-results = SequenceQuery("MTEYKLVVVGAGGVGKSALTIQLIQNHFVDEYDPTIEDSYRKQVVIDGET" +
-                        "CLLDILDTAGQEEYSAMRDQYMRTGEGFLCVFAINNTKSFEDIHQYREQI" +
-                        "KRVKDSDDVPMVLVGNKCDLPARTVETRQAQDLARSYGIPYIETSAKTRQ" +
-                        "GVEDAFYTLVREIRQHKLRKLNPPDESGPGCMNCKCVIS", 1, 0.9)
-    
-# results("polymer_entity") produces an iterator of IDs with return type - polymer entities
-for polyid in results("polymer_entity"):
-    print(polyid)
-```
-### Sequence Motif Search Example
-
-Below is an example from the [RCSB PDB Search API](https://search.rcsb.org/#search-example-6) page,
-using the sequence motif search function. 
-This query retrives occurences of the His2/Cys2 Zinc Finger DNA-binding domain as
-represented by its PROSITE signature. 
-```python
-from rcsbsearchapi.search import SeqMotifQuery
-
-# Use SeqMotifQuery class and add parameters
-results = SeqMotifQuery("C-x(2,4)-C-x(3)-[LIVMFYWC]-x(8)-H-x(3,5)-H.",
-                        pattern_type="prosite",
-                        sequence_type="protein")
-
-# results("polymer_entity") produces an iterator of IDs with return type - polymer entities
-for polyid in results("polymer_entity"):
-    print(polyid)
-```
-
-You can also use a regular expression (RegEx) to make a sequence motif search.
-As an example, here is a query for the zinc finger motif that binds Zn in a DNA-binding domain:
-```python
-from rcsbsearchapi.search import SeqMotifQuery
-
-results = SeqMotifQuery("C.{2,4}C.{12}H.{3,5}H", pattern_type="regex", sequence_type="protein")
-
-for polyid in results("polymer_entity"):
-    print(polyid)
-```
-
-You can use a standard amino acid sequence to make a sequence motif search. 
-X can be used to allow any amino acid in that position. 
-As an example, here is a query for SH3 domains:
-```python
-from rcsbsearchapi.search import SeqMotifQuery
-
-# By default, the pattern_type argument is "simple" and the sequence_type argument is "protein".
-results = SeqMotifQuery("XPPXP")  # X is used as a "variable residue" and can be any amino acid. 
-
-for polyid in results("polymer_entity"):
-    print(polyid)
-```
-
-All 3 of these pattern types can be used to search for DNA and RNA sequences as well.
-Demonstrated are 2 queries, one DNA and one RNA, using the simple pattern type:
-```python
-from rcsbsearchapi.search import SeqMotifQuery
-
-# DNA query: this is a query for a T-Box.
-dna = SeqMotifQuery("TCACACCT", sequence_type="dna")
-
-print("DNA results:")
-for polyid in dna("polymer_entity"):
-    print(polyid)
-
-# RNA query: 6C RNA motif
-rna = SeqMotifQuery("CCCCCC", sequence_type="rna")
-print("RNA results:")
-for polyid in rna("polymer_entity"):
-    print(polyid)
-```
-### Structure Similarity Query Example
-
-The PDB archive can be queried using the 3D shape of a protein structure. To perform this query, 3D protein structure data must be provided as an input or parameter, A chain ID or assembly ID must be specified, whether the input structure data should be compared to Assemblies or Polymer Entity Instance (Chains) is required, and defining the search type as either strict or relaxed is required. More information on how Structure Similarity Queries work can be found on the [RCSB PDB Structure Similarity Search](https://www.rcsb.org/docs/search-and-browse/advanced-search/structure-similarity-search) page.
-```python
-from rcsbsearchapi.search import StructSimilarityQuery
-
-# Basic query: querying using entry ID and default values assembly ID "1", operator "strict", and target search space "Assemblies"
-q1 = StructSimilarityQuery(entry_id="4HHB")
-
-# Same example but with parameters explicitly specified
-q1 = StructSimilarityQuery(structure_search_type="entry_id",
-                           entry_id="4HHB",
-                           structure_input_type="assembly_id",
-                           assembly_id="1",
-                           operator="strict_shape_match",
-                           target_search_space="assembly"
-                           )
-for id in q1("assembly"):
+# Results are returned as an iterator of result identifiers.
+for id in results:
     print(id)
 ```
-Below is a more complex example that utilizes chain ID, relaxed search operator, and polymer entity instance or target search space. Specifying whether the input structure
-type is chain id or assembly id is very important. For example, specifying chain ID as the input structure type but inputting an assembly ID can lead to
-an error.
+
+Besides general text searches, you can also search for specific structure or chemical attributes. 
+
+Using different operators such as `contains_phrase` or `exact_match`, attributes can be compared to a value.
+You can also check whether an attribute exists for a given structure by using the `exists` operator. 
+
+Refer to the [Search Attributes](https://search.rcsb.org/structure-search-attributes.html) and [Chemical Attributes](https://search.rcsb.org/chemical-search-attributes.html) documentation for a full list of attributes and applicable operators.
+
+To search an attribute, you can make an AttributeQuery.
 ```python
-from rcsbsearchapi.search import StructSimilarityQuery
+from rcsbsearchapi import AttributeQuery
 
-# More complex query with entry ID value "4HHB", chain ID "B", operator "relaxed", and target search space "Chains"
-q2 = StructSimilarityQuery(structure_search_type="entry_id",
-                                   entry_id="4HHB",
-                                   structure_input_type="chain_id",
-                                   chain_id="B",
-                                   operator="relaxed_shape_match",
-                                   target_search_space="polymer_entity_instance")
-list(q2())
-```
-Structure similarity queries also allow users to upload a file from their local computer or input a file url from the website to query the PDB archive for similar proteins. The file represents a target protein structure in the file formats "cif", "bcif", "pdb", "cif.gz", or "pdb.gz". If a user wants to use a file url for queries, the user must specify the structure search type, the value (being the url), and the file format of the file. This is also the same case for file upload, except the value is the absolute path leading to the file that is in the local machine. An example for file url is below for 4HHB (hemoglobin).
-```python
-from rcsbsearchapi.search import StructSimilarityQuery
-
-q3 = StructSimilarityQuery(structure_search_type="file_url",
-                           file_url="https://files.rcsb.org/view/4HHB.cif",
-                           file_format="cif")
-list(q3())
-
-# If you want to upload your own structure file for similarity search, you can do so by using the `file_path` parameter:
-q4 = StructSimilarityQuery(structure_search_type="file_upload",
-                           file_path="/PATH/TO/FILE.cif",  # specify local model file path
-                           file_format="cif")
-list(q4())
+# Construct the query
+query = AttributeQuery(
+    attribute="rcsb_entity_source_organism.scientific_name",
+    operator="exact_match",  # other operators include "contains phrase" and "exists"
+    value="Homo sapiens"
+)
+results = list(query())  # construct a list from query results
+print(results)
 ```
 
-### Structure Motif Query Examples
+When using certain operators such as `exact_match`, `greater`, or `less`, you can also use `rcsb_attributes` (imported below as `attrs`).
 
-The PDB Archive can also be queried by using a "motif" found in these 3D structures. To perform this type of query, an entry_id or a file URL/path must be provided, along with residues (which are parts of 3D structures.) This is the bare minimum needed to make a search, but there are lots of other parameters that can be added to a Structure Motif Query (see [full search schema](https://search.rcsb.org/redoc/index.html)).
+Using this syntax, attribute names can be tab-completed. 
 
-To make a Structure Motif Query, you must first define anywhere from 2-10 "residues" that will be used in the query. Each individual residue has a Chain ID, Operator, Residue Number, and Exchanges (optional) that can be declared in that order using positonal arguments, or using the "chain_id", "struct_oper_id", and "label_seq_id" to define what parameter you are passing through. All 3 of the required parameters must be included, or the package will throw an AssertionError. 
-
-Each residue can only have a maximum of 4 Exchanges, and each query can only have 16 exchanges total. Violating any of these rules will cause the package to throw an AssertionError. 
-
-Examples of how to instantiate Residues can be found below. These can then be put into a list and passed through to a Structure Motif Query.
 ```python
-from rcsbsearchapi.search import StructureMotifResidue
+from rcsbsearchapi import rcsb_attributes as attrs
 
-# construct a Residue with a Chain ID of A, an operator of 1, a residue 
-# number of 192, and Exchanges of "LYS" and "HIS"
-Res1 = StructureMotifResidue("A", "1", 192, ["LYS", "HIS"])
-# as for what is a valid "Exchange", the package provides these as a literal,
-# and they should be type checked. 
-
-# you can also specify the arguments:
-# this query is the same as above. 
-Res2 = StructureMotifResidue(struct_oper_id="1", chain_id="A", exchanges=["LYS", "HIS"], label_seq_id=192)
-
-# after delcaring a minimum of 2 and as many as 10 residues, they can be passed into a list for use in the query itself:
-Res3 = StructureMotifResidue("A", "1", 162)  # exchanges are optional
-
-ResList = [Res1, Res3]
-```
-From there, these Residues can be used in a query. As stated before, you can only include 2 - 10 residues in a query. If you fail to provide residues for a query, or provide the wrong amount, the package will throw a ValueError. 
-
-For a Structure Motif Query using an entry_id, the only other necessary value that must be passed into the query is the residue list. The default type of query is an entry_id query. 
-
-As this type of query has a lot of optional parameters, do *not* use positional arguments as more than likely an error will occur. 
-
-Below is an example of a basic entry_id Structure Motif Query, with the residues declared earlier:
-```python
-from rcsbsearchapi.search import StructMotifQuery
-
-q1 = StructMotifQuery(entry_id="2MNR", residue_ids=ResList)
-list(q1())
-```
-Like with Structure Similarity Queries, a file url or filepath can also be provided to the program. These can take the place of an entry_id. 
-
-For a file url query, you *must* provide both a valid file URL (a string), and the file's file extension (also as a string). Failure to provide these elements correctly will cause the package to throw an AssertionError. 
-
-Below is an example of the same query as above, only this time providing a file url:
-```python
-link = "https://files.rcsb.org/view/2MNR.cif"
-q2 = StructMotifQuery(structure_search_type="file_url", url=link, file_extension="cif", residue_ids=ResList)
-# structure_search_type MUST be provided. A mismatched query type will cause an error. 
-list(q2())
-```
-Like with Structure Similarity Queries, a filepath to a file may also be provided. This file must be a valid file accepted by the search API. A file extension must also be provided with the file upload. 
-
-The query would look something like this:
-```python
-filepath = "/absolute/path/to/file.cif"
-q3 = StructMotifQuery(structure_search_type="file_upload", file_path=filepath, file_extension="cif", residue_ids=ResList)
-
-list(q3())
-```
-There are many additional parameters that Structure Motif Query supports. These include a variety of features such as backbone distance tolerance, side chain distance tolerance, angle tolerance, RMSD cutoff, limits (stop searching after this many hits), atom pairing schemes, motif pruning strategy, allowed structures, and excluded structures. These can be mixed and matched as needed to make accurate and useful queries. All of these have some default value which is used when a parameter isn't provided. These parameters conform to the defaults used by the Search API. 
-
-Below will demonstrate how to define these parameters using non-positional arguments:
-```python
-# specifying backbone distance tolerance: 0-3, default is 1
-# allowed backbone distance tolerance in Angstrom. 
-backbone = StructMotifQuery(entry_id="2MNR", backbone_distance_tolerance=2, residue_ids=ResList)
-list(backbone())
-
-# specifying sidechain distance tolerance: 0-3, default is 1
-# allowed side-chain distance tolerance in Angstrom.
-sidechain = StructMotifQuery(entry_id="2MNR", side_chain_distance_tolerance=2, residue_ids=ResList)
-list(sidechain())
-
-# specifying angle tolerance: 0-3, default is 1
-# allowed angle tolerance in multiples of 20 degrees. 
-angle = StructMotifQuery(entry_id="2MNR", angle_tolerance=2, residue_ids=ResList)
-list(angle())
-
-# specifying RMSD cutoff: >=0, default is 2
-# Threshold above which hits will be filtered by RMSD
-rmsd = StructMotifQuery(entry_id="2MNR", rmsd_cutoff=1, residue_ids=ResList)
-list(rmsd())
-
-# specifying limit: >=0, default excluded
-# Stop accepting results after this many hits. 
-limit = StructMotifQuery(entry_id="2MNR", limit=100, residue_ids=ResList)
-list(limit())
-
-# specifying atom pairing scheme, default = "SIDE_CHAIN"
-# ENUM: "ALL", "BACKBONE", "SIDE_CHAIN", "PSUEDO_ATOMS"
-# this is typechecked by a literal. 
-# Which atoms to consider to compute RMSD scores and transformations. 
-atom = StructMotifQuery(entry_id="2MNR", atom_pairing_scheme="ALL", residue_ids=ResList)
-list(atom())
-
-# specifying motif pruning strategy, default = "KRUSKAL"
-# ENUM: "NONE", "KRUSKAL"
-# this is typechecked by a literal in the package. 
-# Specifies how many query motifs are "pruned". KRUSKAL leads to less stringent queries, and faster results.
-pruning = StructMotifQuery(entry_id="2MNR", motif_pruning_strategy="NONE", residue_ids=ResList)
-list(pruning())
-
-# specifying allowed structures, default excluded
-# specify the structures you wish to allow in the return result. As an example,
-# we could only allow the results from the limited query we ran earlier. 
-allowed = StructMotifQuery(entry_id="2MNR", allowed_structures=list(limit()), residue_ids=ResList)
-list(allowed())
-
-# specifying structures to exclude, default excluded
-# specify structures to exclude from a query. We could, for example,
-# exclude the results of the previous allowed query. 
-excluded = StructMotifQuery(entry_id="2MNR", excluded_structures=list(allowed()), residue_ids=ResList)
-list(excluded())
-```
-The Structure Motif Query can be used to make some very specific queries. Below is an example of a query that retrives occurances of the enolase superfamily, a group of proteins diverse in sequence and structure that are all capable of abstracting a proton from a carboxylic acid. Position-specific exchanges are crucial to represent this superfamily accurately.
-```python
-Res1 = StructureMotifResidue("A", "1", 162, ["LYS", "HIS"])
-Res2 = StructureMotifResidue("A", "1", 193)
-Res3 = StructureMotifResidue("A", "1", 219)
-Res4 = StructureMotifResidue("A", "1", 245, ["GLU", "ASP", "ASN"])
-Res5 = StructureMotifResidue("A", "1", 295, ["HIS", "LYS"])
-
-ResList = [Res1, Res2, Res3, Res4, Res5]
-
-query = StructMotifQuery(entry_id="2MNR", residue_ids=ResList)
-
-list(query())
-```
-### Chemical Similarity Query
-
-When you have unique chemical information (e.g., a chemical formula or descriptor) you can use this information to find chemical components (e.g., drugs, inhibitors, modified residues, or building blocks such as amino acids, nucleotides, or sugars), so that it is similar to the formula or descriptor used in the query (perhaps one or two atoms/groups are different), is part of a larger molecule (i.e., the specified formula/descriptor is a substructure), or is exactly or very closely matches the formula or descriptor used in the query. 
-
-The search can also be used to identify PDB structures that include the chemical component(s) which match or are similar to the query. These structures can then be examined to learn about the interactions of the component within the structure. More information on Chemical Similarity Queries can be found on the [RCSB PDB Chemical Similarity Search](https://www.rcsb.org/docs/search-and-browse/advanced-search/chemical-similarity-search) page.
-
-To do a Chemical Similarity query, you must first specify one of two possible query options which are formula and descriptors. Formula allows queries to be made by providing a chemical formula. Descriptors allow you to search by chemical notations for example. Each Query option has its own distinct set of parameters, but both options require a value.
-
-The formula query option comes with a match subset parameter which allows users to search chemical components whose formula exactly match the query or matches any portion of the query. The descriptor query option comes with a descriptor type parameter and match type parameter. The descriptor type parameter specifies what type of descriptor the input value is. There are two options which are SMILES (Simplified Molecular Input Line Entry Specification) and InChI (International Chemical Identifier). The match type parameter has six options which are Similar Ligands (Quick Screen), Similar Ligands (Stereospecific), Similar Ligands (including Stereoisomers), Substructure (Stereospecific), Substructure (including Stereoisomers), and Exact match.
-
-When doing Chemical Similarity Queries in this tool, it is important to note that by default the query option is set to formula and match subset is set to False. An example of how that looks like is below.
-```python
-from rcsbsearchapi.search import ChemSimilarityQuery
-
-# Basic query with default values: query type = formula and match subset = False
-q1 = ChemSimilarityQuery(value="C12 H17 N4 O S")
-
-# Same example but with all the parameters listed
-q1 = ChemSimilarityQuery(value="C12 H17 N4 O S",
-                         query_type="formula",
-                         match_subset=False)
-list(q1())
-```
-Below is are two examples of using query option descriptor. Both descriptor type parameters are also used.
-```python
-from rcsbsearchapi.search import ChemSimilarityQuery
-
-# Query with type = descriptor, descriptor type = SMILES, match type = similar ligands (sterospecific) or graph-relaxed-stereo
-q2 = ChemSimilarityQuery(value="Cc1c(sc[n+]1Cc2cnc(nc2N)C)CCO",
-                         query_type="descriptor",
-                         descriptor_type="SMILES",
-                         match_type="graph-relaxed-stereo")
-list(q2())
-```
-```python
-from rcsbsearchapi.search import ChemSimilarityQuery
-
-# Query with type = descriptor, descriptor type = InChI, match type = substructure (sterospecific) or sub-struct-graph-relaxed-stereo
-q3 = ChemSimilarityQuery(value="InChI=1S/C13H10N2O4/c16-10-6-5-9(11(17)14-10)15-12(18)7-3-1-2-4-8(7)13(15)19/h1-4,9H,5-6H2,(H,14,16,17)/t9-/m0/s1",
-                         query_type="descriptor",
-                         descriptor_type="InChI",
-                         match_type="sub-struct-graph-relaxed-stereo")
-list(q3())
+# Search for structures from humans
+query = attrs.rcsb_entity_source_organism.scientific_name == "Homo sapiens"
+results = list(query())  # construct a list from query results
+print(results)
 ```
 
-### Faceted Query Examples
-In order to group and perform calculations and statistics on PDB data by using a simple search query, you can use a faceted query (or facets). Facets arrange search results into categories (buckets) based on the requested field values. More information on Faceted Queries can be found [here](https://search.rcsb.org/#using-facets). All facets should be provided with `name`, `aggregation_type`, and `attribute` values. Depending on the aggregation type, other parameters must also be specified. The `facets()` function runs the query `q` using the specified facet(s), and returns a list of dictionaries:
-```python
-from rcsbsearchapi.search import AttributeQuery, Facet, Range
+You can combine multiple queries using Python bitwise operators. 
 
-q = AttributeQuery("rcsb_accession_info.initial_release_date", operator="greater", value="2019-08-20")
-q.facets(facets=Facet(name="Methods", aggregation_type="terms", attribute="exptl.method"))
+|Operator|Description             |
+|--------|------------------------|
+|&       |AND                     |
+|\|      |OR                      |
+|~       |NOT                     |
+|-       |set difference          |
+|^       |symmetric difference/XOR|
+
+```python
+from rcsbsearchapi import rcsb_attributes as attrs
+
+# Query for human epidermal growth factor receptor (EGFR) structures with investigational or experimental drugs
+# EGFR is involved in cell division and often overexpressed or mutated in some cancers
+q1 = attrs.rcsb_polymer_entity_container_identifiers.reference_sequence_identifiers.database_accession == "P00533"
+q2 = attrs.rcsb_entity_source_organism.scientific_name == "Homo sapiens"
+q3 = attrs.drugbank_info.drug_groups == "investigational"
+q4 = attrs.drugbank_info.drug_groups == "experimental"
+
+# Structures matching UniProt id P00533 AND from humans AND (investigational or experimental drug group)
+query = q1 & q2 & (q3 | q4)
+
+# Execute query and print first 10 ids
+results = list(query())
+print(results[:10])
 ```
 
-#### Term Facets
-Terms faceting is a multi-bucket aggregation where buckets are dynamically built - one per unique value. We can specify the minimum count (`>= 0`) for a bucket to be returned using the parameter `min_interval_population` (default value `1`). We can also control the number of buckets returned (`<= 65336`) using the parameter `max_num_intervals` (default value `65336`).
-```python
-# This is the default query, used by the RCSB Search API when no query is explicitly specified.
-# This default query will be used for most of the examples found below for faceted queries.
-base_q = AttributeQuery("rcsb_entry_info.structure_determination_methodology", operator="exact_match", value="experimental") 
+These examples are in `operator syntax`. You can also make queries in `fluent syntax`. Learn more about both syntaxes and implementation details in [readthedocs: Queries](https://rcsbsearchapi.readthedocs.io/en/latest/queries.html).
 
-base_q.facets(facets=Facet(name="Journals", aggregation_type="terms", attribute="rcsb_primary_citation.rcsb_journal_abbrev", min_interval_population=1000))
-```
+## Jupyter Notebooks
+A runnable jupyter notebook with this example is available in [notebooks/quickstart.ipynb](notebooks/quickstart.ipynb), or can be run online using Google Colab:
+<a href="https://colab.research.google.com/github/rcsb/py-rcsbsearchapi/blob/master/notebooks/quickstart.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
 
-#### Histogram Facets
-Histogram facets build fixed-sized buckets (intervals) over numeric values. The size of the intervals must be specified in the parameter `interval`. We can also specify `min_interval_population` if desired.
-```python
-base_q.facets(return_type="polymer_entity", facets=Facet(name="Formula Weight", aggregation_type="histogram", attribute="rcsb_polymer_entity.formula_weight", interval=50, min_interval_population=1))
-```
-
-#### Date Histogram Facets
-Similar to histogram facets, date histogram facetes build buckets over date values. For date histogram aggregations, we must specify `interval="year"`. Again, we may also specify `min_interval_population`.
-```python
-base_q.facets(facets=Facet(name="Release Date", aggregation_type="date_histogram", attribute="rcsb_accession_info.initial_release_date", interval="year", min_interval_population=1))
-```
-
-#### Range Facets
-We can define the buckets ourselves by using range facets. In order to specify the ranges, we use the `Range` class. Note that the range includes the `start` value and excludes the `end` value (`include_lower` and `include_upper` should not be specified). If the `start` or `end` is omitted, the minimum or maximum boundaries will be used by default. The buckets should be provided as a list of `Range` objects to the `ranges` parameter.  
-```python
-base_q.facets(facets=Facet(name="Resolution Combined", aggregation_type="range", attribute="rcsb_entry_info.resolution_combined", ranges=[Range(start=None,end=2), Range(start=2, end=2.2), Range(start=2.2, end=2.4), Range(start=4.6, end=None)]))
-```
-
-#### Date Range Facets
-Date range facets allow us to specify date values as bucket ranges, using [date math expressions](https://search.rcsb.org/#date-math-expressions).
-```python
-base_q.facets(facets=Facet(name="Release Date", aggregation_type="date_range", attribute="rcsb_accession_info.initial_release_date", ranges=[Range(start=None,end="2020-06-01||-12M"), Range(start="2020-06-01", end="2020-06-01||+12M"), Range(start="2020-06-01||+12M", end=None)]))
-```
-
-#### Cardinality Facets 
-Cardinality facets return a single value: the count of distinct values returned for a given field. A `precision_threshold` (`<= 40000`, default value `40000`) may be specified.
-```python
-base_q.facets(facets=Facet(name="Organism Names Count", aggregation_type="cardinality", attribute="rcsb_entity_source_organism.ncbi_scientific_name"))
-```
-
-#### Multidimensional Facets
-Complex, multi-dimensional aggregations are possible by specifying additional facets in the `nested_facets` parameter, as in the example below:
-```python
-f1 = Facet(name="Polymer Entity Types", aggregation_type="terms", attribute="rcsb_entry_info.selected_polymer_entity_types")
-f2 = Facet(name="Release Date", aggregation_type="date_histogram", attribute="rcsb_accession_info.initial_release_date", interval="year")
-base_q.facets(facets=Facet(name="Experimental Method", aggregation_type="terms", attribute="rcsb_entry_info.experimental_method", nested_facets=[f1, f2]))
-```
-
-#### Filter Facets
-Filters allow us to filter documents that contribute to bucket count. Similar to queries, we can group several `TerminalFilter`s into a single `GroupFilter`. We can combine a filter with a facet using the `FilterFacet` class. Terminal filters should specify an `attribute` and `operator`, as well as possible a `value` and whether or not it should be a `negation` and/or `case_sensitive`. Group filters should specify a `logical_operator` (which should be either `"and"` or `"or"`) and a list of filters (`nodes`) that should be combined. Finally, the `FilterFacet` should be provided with a filter and a (list of) facet(s). Here are some examples:
-```python
-from rcsbsearchapi.search import TerminalFilter, GroupFilter, FilterFacet
-tf1 = TerminalFilter(attribute="rcsb_polymer_instance_annotation.type", operator="exact_match", value="CATH")
-tf2 = TerminalFilter(attribute="rcsb_polymer_instance_annotation.annotation_lineage.id", operator="in", value=["2.140.10.30", "2.120.10.80"])
-ff2 = FilterFacet(filters=tf2, facets=Facet("CATH Domains", "terms", "rcsb_polymer_instance_annotation.annotation_lineage.id", min_interval_population=1))
-ff1 = FilterFacet(filters=tf1, facets=ff2)
-base_q.facets("polymer_instance", ff1)
-
-tf1 = TerminalFilter(attribute="rcsb_struct_symmetry.kind", operator="exact_match", value="Global Symmetry", negation=False)
-f2 = Facet(name="ec_terms", aggregation_type="terms", attribute="rcsb_polymer_entity.rcsb_ec_lineage.id")
-f1 = Facet(name="sym_symbol_terms", aggregation_type="terms", attribute="rcsb_struct_symmetry.symbol", nested_facets=f2)
-ff = FilterFacet(filters=tf1, facets=f1)
-q1 = AttributeQuery("rcsb_assembly_info.polymer_entity_count", operator="equals", value=1)
-q2 = AttributeQuery("rcsb_assembly_info.polymer_entity_instance_count", operator="greater", value=1)
-q = q1 & q2
-q.facets("assembly", ff)
-
-tf1 = TerminalFilter(attribute="rcsb_polymer_entity_group_membership.aggregation_method", operator="exact_match", value="sequence_identity")
-tf2 = TerminalFilter(attribute="rcsb_polymer_entity_group_membership.similarity_cutoff", operator="equals", value=100)
-gf = GroupFilter(logical_operator="and", nodes=[tf1, tf2])
-ff = FilterFacet(filters=gf, facets=Facet("Distinct Protein Sequence Count", "cardinality", "rcsb_polymer_entity_group_membership.group_id"))
-base_q.facets("polymer_entity", ff)
-```
+An additional example including a Covid-19 related example is in [notebooks/covid.ipynb](notebooks/covid.ipynb):
+<a href="https://colab.research.google.com/github//rcsb/py-rcsbsearchapi/blob/master/notebooks/covid.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
 
 ## Supported Features
 
@@ -566,10 +125,6 @@ The following table lists the status of current and planned features.
 - [ ] Rich results using the Data API
 
 Contributions are welcome for unchecked items!
-
-## Documentation
-
-Detailed documentation is at [rcsbsearchapi.readthedocs.io](https://rcsbsearchapi.readthedocs.io/en/latest/)
 
 ## License
 

--- a/docs/additional_examples.md
+++ b/docs/additional_examples.md
@@ -1,0 +1,388 @@
+# Additional Examples
+
+## Protein Sequence Search Example
+
+Below is an example from the [RCSB PDB Search API](https://search.rcsb.org/#search-example-3) page, 
+using the sequence search function.
+This query finds macromolecular PDB entities that share 90% sequence identity with
+GTPase HRas protein from *Gallus gallus* (*Chicken*).
+```python
+from rcsbsearchapi.search import SequenceQuery
+
+# Use SequenceQuery class and add parameters
+results = SequenceQuery("MTEYKLVVVGAGGVGKSALTIQLIQNHFVDEYDPTIEDSYRKQVVIDGET" +
+                        "CLLDILDTAGQEEYSAMRDQYMRTGEGFLCVFAINNTKSFEDIHQYREQI" +
+                        "KRVKDSDDVPMVLVGNKCDLPARTVETRQAQDLARSYGIPYIETSAKTRQ" +
+                        "GVEDAFYTLVREIRQHKLRKLNPPDESGPGCMNCKCVIS", 1, 0.9)
+    
+# results("polymer_entity") produces an iterator of IDs with return type - polymer entities
+for polyid in results("polymer_entity"):
+    print(polyid)
+```
+## Sequence Motif Search Example
+
+Below is an example from the [RCSB PDB Search API](https://search.rcsb.org/#search-example-6) page,
+using the sequence motif search function. 
+This query retrives occurences of the His2/Cys2 Zinc Finger DNA-binding domain as
+represented by its PROSITE signature. 
+```python
+from rcsbsearchapi.search import SeqMotifQuery
+
+# Use SeqMotifQuery class and add parameters
+results = SeqMotifQuery("C-x(2,4)-C-x(3)-[LIVMFYWC]-x(8)-H-x(3,5)-H.",
+                        pattern_type="prosite",
+                        sequence_type="protein")
+
+# results("polymer_entity") produces an iterator of IDs with return type - polymer entities
+for polyid in results("polymer_entity"):
+    print(polyid)
+```
+
+You can also use a regular expression (RegEx) to make a sequence motif search.
+As an example, here is a query for the zinc finger motif that binds Zn in a DNA-binding domain:
+```python
+from rcsbsearchapi.search import SeqMotifQuery
+
+results = SeqMotifQuery("C.{2,4}C.{12}H.{3,5}H", pattern_type="regex", sequence_type="protein")
+
+for polyid in results("polymer_entity"):
+    print(polyid)
+```
+
+You can use a standard amino acid sequence to make a sequence motif search. 
+X can be used to allow any amino acid in that position. 
+As an example, here is a query for SH3 domains:
+```python
+from rcsbsearchapi.search import SeqMotifQuery
+
+# By default, the pattern_type argument is "simple" and the sequence_type argument is "protein".
+results = SeqMotifQuery("XPPXP")  # X is used as a "variable residue" and can be any amino acid. 
+
+for polyid in results("polymer_entity"):
+    print(polyid)
+```
+
+All 3 of these pattern types can be used to search for DNA and RNA sequences as well.
+Demonstrated are 2 queries, one DNA and one RNA, using the simple pattern type:
+```python
+from rcsbsearchapi.search import SeqMotifQuery
+
+# DNA query: this is a query for a T-Box.
+dna = SeqMotifQuery("TCACACCT", sequence_type="dna")
+
+print("DNA results:")
+for polyid in dna("polymer_entity"):
+    print(polyid)
+
+# RNA query: 6C RNA motif
+rna = SeqMotifQuery("CCCCCC", sequence_type="rna")
+print("RNA results:")
+for polyid in rna("polymer_entity"):
+    print(polyid)
+```
+## Structure Similarity Query Example
+
+The PDB archive can be queried using the 3D shape of a protein structure. To perform this query, 3D protein structure data must be provided as an input or parameter, A chain ID or assembly ID must be specified, whether the input structure data should be compared to Assemblies or Polymer Entity Instance (Chains) is required, and defining the search type as either strict or relaxed is required. More information on how Structure Similarity Queries work can be found on the [RCSB PDB Structure Similarity Search](https://www.rcsb.org/docs/search-and-browse/advanced-search/structure-similarity-search) page.
+```python
+from rcsbsearchapi.search import StructSimilarityQuery
+
+# Basic query: querying using entry ID and default values assembly ID "1", operator "strict", and target search space "Assemblies"
+q1 = StructSimilarityQuery(entry_id="4HHB")
+
+# Same example but with parameters explicitly specified
+q1 = StructSimilarityQuery(structure_search_type="entry_id",
+                           entry_id="4HHB",
+                           structure_input_type="assembly_id",
+                           assembly_id="1",
+                           operator="strict_shape_match",
+                           target_search_space="assembly"
+                           )
+for id in q1("assembly"):
+    print(id)
+```
+Below is a more complex example that utilizes chain ID, relaxed search operator, and polymer entity instance or target search space. Specifying whether the input structure
+type is chain id or assembly id is very important. For example, specifying chain ID as the input structure type but inputting an assembly ID can lead to
+an error.
+```python
+from rcsbsearchapi.search import StructSimilarityQuery
+
+# More complex query with entry ID value "4HHB", chain ID "B", operator "relaxed", and target search space "Chains"
+q2 = StructSimilarityQuery(structure_search_type="entry_id",
+                                   entry_id="4HHB",
+                                   structure_input_type="chain_id",
+                                   chain_id="B",
+                                   operator="relaxed_shape_match",
+                                   target_search_space="polymer_entity_instance")
+list(q2())
+```
+Structure similarity queries also allow users to upload a file from their local computer or input a file url from the website to query the PDB archive for similar proteins. The file represents a target protein structure in the file formats "cif", "bcif", "pdb", "cif.gz", or "pdb.gz". If a user wants to use a file url for queries, the user must specify the structure search type, the value (being the url), and the file format of the file. This is also the same case for file upload, except the value is the absolute path leading to the file that is in the local machine. An example for file url is below for 4HHB (hemoglobin).
+```python
+from rcsbsearchapi.search import StructSimilarityQuery
+
+q3 = StructSimilarityQuery(structure_search_type="file_url",
+                           file_url="https://files.rcsb.org/view/4HHB.cif",
+                           file_format="cif")
+list(q3())
+
+# If you want to upload your own structure file for similarity search, you can do so by using the `file_path` parameter:
+q4 = StructSimilarityQuery(structure_search_type="file_upload",
+                           file_path="/PATH/TO/FILE.cif",  # specify local model file path
+                           file_format="cif")
+list(q4())
+```
+
+## Structure Motif Query Examples
+
+The PDB Archive can also be queried by using a "motif" found in these 3D structures. To perform this type of query, an entry_id or a file URL/path must be provided, along with residues (which are parts of 3D structures.) This is the bare minimum needed to make a search, but there are lots of other parameters that can be added to a Structure Motif Query (see [full search schema](https://search.rcsb.org/redoc/index.html)).
+
+To make a Structure Motif Query, you must first define anywhere from 2-10 "residues" that will be used in the query. Each individual residue has a Chain ID, Operator, Residue Number, and Exchanges (optional) that can be declared in that order using positonal arguments, or using the "chain_id", "struct_oper_id", and "label_seq_id" to define what parameter you are passing through. All 3 of the required parameters must be included, or the package will throw an AssertionError. 
+
+Each residue can only have a maximum of 4 Exchanges, and each query can only have 16 exchanges total. Violating any of these rules will cause the package to throw an AssertionError. 
+
+Examples of how to instantiate Residues can be found below. These can then be put into a list and passed through to a Structure Motif Query.
+```python
+from rcsbsearchapi.search import StructureMotifResidue
+
+# construct a Residue with a Chain ID of A, an operator of 1, a residue 
+# number of 192, and Exchanges of "LYS" and "HIS"
+Res1 = StructureMotifResidue("A", "1", 192, ["LYS", "HIS"])
+# as for what is a valid "Exchange", the package provides these as a literal,
+# and they should be type checked. 
+
+# you can also specify the arguments:
+# this query is the same as above. 
+Res2 = StructureMotifResidue(struct_oper_id="1", chain_id="A", exchanges=["LYS", "HIS"], label_seq_id=192)
+
+# after delcaring a minimum of 2 and as many as 10 residues, they can be passed into a list for use in the query itself:
+Res3 = StructureMotifResidue("A", "1", 162)  # exchanges are optional
+
+ResList = [Res1, Res3]
+```
+From there, these Residues can be used in a query. As stated before, you can only include 2 - 10 residues in a query. If you fail to provide residues for a query, or provide the wrong amount, the package will throw a ValueError. 
+
+For a Structure Motif Query using an entry_id, the only other necessary value that must be passed into the query is the residue list. The default type of query is an entry_id query. 
+
+As this type of query has a lot of optional parameters, do *not* use positional arguments as more than likely an error will occur. 
+
+Below is an example of a basic entry_id Structure Motif Query, with the residues declared earlier:
+```python
+from rcsbsearchapi.search import StructMotifQuery
+
+q1 = StructMotifQuery(entry_id="2MNR", residue_ids=ResList)
+list(q1())
+```
+Like with Structure Similarity Queries, a file url or filepath can also be provided to the program. These can take the place of an entry_id. 
+
+For a file url query, you *must* provide both a valid file URL (a string), and the file's file extension (also as a string). Failure to provide these elements correctly will cause the package to throw an AssertionError. 
+
+Below is an example of the same query as above, only this time providing a file url:
+```python
+link = "https://files.rcsb.org/view/2MNR.cif"
+q2 = StructMotifQuery(structure_search_type="file_url", url=link, file_extension="cif", residue_ids=ResList)
+# structure_search_type MUST be provided. A mismatched query type will cause an error. 
+list(q2())
+```
+Like with Structure Similarity Queries, a filepath to a file may also be provided. This file must be a valid file accepted by the search API. A file extension must also be provided with the file upload. 
+
+The query would look something like this:
+```python
+filepath = "/absolute/path/to/file.cif"
+q3 = StructMotifQuery(structure_search_type="file_upload", file_path=filepath, file_extension="cif", residue_ids=ResList)
+
+list(q3())
+```
+There are many additional parameters that Structure Motif Query supports. These include a variety of features such as backbone distance tolerance, side chain distance tolerance, angle tolerance, RMSD cutoff, limits (stop searching after this many hits), atom pairing schemes, motif pruning strategy, allowed structures, and excluded structures. These can be mixed and matched as needed to make accurate and useful queries. All of these have some default value which is used when a parameter isn't provided. These parameters conform to the defaults used by the Search API. 
+
+Below will demonstrate how to define these parameters using non-positional arguments:
+```python
+# specifying backbone distance tolerance: 0-3, default is 1
+# allowed backbone distance tolerance in Angstrom. 
+backbone = StructMotifQuery(entry_id="2MNR", backbone_distance_tolerance=2, residue_ids=ResList)
+list(backbone())
+
+# specifying sidechain distance tolerance: 0-3, default is 1
+# allowed side-chain distance tolerance in Angstrom.
+sidechain = StructMotifQuery(entry_id="2MNR", side_chain_distance_tolerance=2, residue_ids=ResList)
+list(sidechain())
+
+# specifying angle tolerance: 0-3, default is 1
+# allowed angle tolerance in multiples of 20 degrees. 
+angle = StructMotifQuery(entry_id="2MNR", angle_tolerance=2, residue_ids=ResList)
+list(angle())
+
+# specifying RMSD cutoff: >=0, default is 2
+# Threshold above which hits will be filtered by RMSD
+rmsd = StructMotifQuery(entry_id="2MNR", rmsd_cutoff=1, residue_ids=ResList)
+list(rmsd())
+
+# specifying limit: >=0, default excluded
+# Stop accepting results after this many hits. 
+limit = StructMotifQuery(entry_id="2MNR", limit=100, residue_ids=ResList)
+list(limit())
+
+# specifying atom pairing scheme, default = "SIDE_CHAIN"
+# ENUM: "ALL", "BACKBONE", "SIDE_CHAIN", "PSUEDO_ATOMS"
+# this is typechecked by a literal. 
+# Which atoms to consider to compute RMSD scores and transformations. 
+atom = StructMotifQuery(entry_id="2MNR", atom_pairing_scheme="ALL", residue_ids=ResList)
+list(atom())
+
+# specifying motif pruning strategy, default = "KRUSKAL"
+# ENUM: "NONE", "KRUSKAL"
+# this is typechecked by a literal in the package. 
+# Specifies how many query motifs are "pruned". KRUSKAL leads to less stringent queries, and faster results.
+pruning = StructMotifQuery(entry_id="2MNR", motif_pruning_strategy="NONE", residue_ids=ResList)
+list(pruning())
+
+# specifying allowed structures, default excluded
+# specify the structures you wish to allow in the return result. As an example,
+# we could only allow the results from the limited query we ran earlier. 
+allowed = StructMotifQuery(entry_id="2MNR", allowed_structures=list(limit()), residue_ids=ResList)
+list(allowed())
+
+# specifying structures to exclude, default excluded
+# specify structures to exclude from a query. We could, for example,
+# exclude the results of the previous allowed query. 
+excluded = StructMotifQuery(entry_id="2MNR", excluded_structures=list(allowed()), residue_ids=ResList)
+list(excluded())
+```
+The Structure Motif Query can be used to make some very specific queries. Below is an example of a query that retrives occurances of the enolase superfamily, a group of proteins diverse in sequence and structure that are all capable of abstracting a proton from a carboxylic acid. Position-specific exchanges are crucial to represent this superfamily accurately.
+```python
+Res1 = StructureMotifResidue("A", "1", 162, ["LYS", "HIS"])
+Res2 = StructureMotifResidue("A", "1", 193)
+Res3 = StructureMotifResidue("A", "1", 219)
+Res4 = StructureMotifResidue("A", "1", 245, ["GLU", "ASP", "ASN"])
+Res5 = StructureMotifResidue("A", "1", 295, ["HIS", "LYS"])
+
+ResList = [Res1, Res2, Res3, Res4, Res5]
+
+query = StructMotifQuery(entry_id="2MNR", residue_ids=ResList)
+
+list(query())
+```
+## Chemical Similarity Query
+
+When you have unique chemical information (e.g., a chemical formula or descriptor) you can use this information to find chemical components (e.g., drugs, inhibitors, modified residues, or building blocks such as amino acids, nucleotides, or sugars), so that it is similar to the formula or descriptor used in the query (perhaps one or two atoms/groups are different), is part of a larger molecule (i.e., the specified formula/descriptor is a substructure), or is exactly or very closely matches the formula or descriptor used in the query. 
+
+The search can also be used to identify PDB structures that include the chemical component(s) which match or are similar to the query. These structures can then be examined to learn about the interactions of the component within the structure. More information on Chemical Similarity Queries can be found on the [RCSB PDB Chemical Similarity Search](https://www.rcsb.org/docs/search-and-browse/advanced-search/chemical-similarity-search) page.
+
+To do a Chemical Similarity query, you must first specify one of two possible query options which are formula and descriptors. Formula allows queries to be made by providing a chemical formula. Descriptors allow you to search by chemical notations for example. Each Query option has its own distinct set of parameters, but both options require a value.
+
+The formula query option comes with a match subset parameter which allows users to search chemical components whose formula exactly match the query or matches any portion of the query. The descriptor query option comes with a descriptor type parameter and match type parameter. The descriptor type parameter specifies what type of descriptor the input value is. There are two options which are SMILES (Simplified Molecular Input Line Entry Specification) and InChI (International Chemical Identifier). The match type parameter has six options which are Similar Ligands (Quick Screen), Similar Ligands (Stereospecific), Similar Ligands (including Stereoisomers), Substructure (Stereospecific), Substructure (including Stereoisomers), and Exact match.
+
+When doing Chemical Similarity Queries in this tool, it is important to note that by default the query option is set to formula and match subset is set to False. An example of how that looks like is below.
+```python
+from rcsbsearchapi.search import ChemSimilarityQuery
+
+# Basic query with default values: query type = formula and match subset = False
+q1 = ChemSimilarityQuery(value="C12 H17 N4 O S")
+
+# Same example but with all the parameters listed
+q1 = ChemSimilarityQuery(value="C12 H17 N4 O S",
+                         query_type="formula",
+                         match_subset=False)
+list(q1())
+```
+Below is are two examples of using query option descriptor. Both descriptor type parameters are also used.
+```python
+from rcsbsearchapi.search import ChemSimilarityQuery
+
+# Query with type = descriptor, descriptor type = SMILES, match type = similar ligands (sterospecific) or graph-relaxed-stereo
+q2 = ChemSimilarityQuery(value="Cc1c(sc[n+]1Cc2cnc(nc2N)C)CCO",
+                         query_type="descriptor",
+                         descriptor_type="SMILES",
+                         match_type="graph-relaxed-stereo")
+list(q2())
+```
+```python
+from rcsbsearchapi.search import ChemSimilarityQuery
+
+# Query with type = descriptor, descriptor type = InChI, match type = substructure (sterospecific) or sub-struct-graph-relaxed-stereo
+q3 = ChemSimilarityQuery(value="InChI=1S/C13H10N2O4/c16-10-6-5-9(11(17)14-10)15-12(18)7-3-1-2-4-8(7)13(15)19/h1-4,9H,5-6H2,(H,14,16,17)/t9-/m0/s1",
+                         query_type="descriptor",
+                         descriptor_type="InChI",
+                         match_type="sub-struct-graph-relaxed-stereo")
+list(q3())
+```
+## Faceted Query Examples
+In order to group and perform calculations and statistics on PDB data by using a simple search query, you can use a faceted query (or facets). Facets arrange search results into categories (buckets) based on the requested field values. More information on Faceted Queries can be found [here](https://search.rcsb.org/#using-facets). All facets should be provided with `name`, `aggregation_type`, and `attribute` values. Depending on the aggregation type, other parameters must also be specified. The `facets()` function runs the query `q` using the specified facet(s), and returns a list of dictionaries:
+```python
+from rcsbsearchapi.search import AttributeQuery, Facet, Range
+
+q = AttributeQuery("rcsb_accession_info.initial_release_date", operator="greater", value="2019-08-20")
+q.facets(facets=Facet(name="Methods", aggregation_type="terms", attribute="exptl.method"))
+```
+
+### Term Facets
+Terms faceting is a multi-bucket aggregation where buckets are dynamically built - one per unique value. We can specify the minimum count (`>= 0`) for a bucket to be returned using the parameter `min_interval_population` (default value `1`). We can also control the number of buckets returned (`<= 65336`) using the parameter `max_num_intervals` (default value `65336`).
+```python
+# This is the default query, used by the RCSB Search API when no query is explicitly specified.
+# This default query will be used for most of the examples found below for faceted queries.
+base_q = AttributeQuery("rcsb_entry_info.structure_determination_methodology", operator="exact_match", value="experimental") 
+
+base_q.facets(facets=Facet(name="Journals", aggregation_type="terms", attribute="rcsb_primary_citation.rcsb_journal_abbrev", min_interval_population=1000))
+```
+
+### Histogram Facets
+Histogram facets build fixed-sized buckets (intervals) over numeric values. The size of the intervals must be specified in the parameter `interval`. We can also specify `min_interval_population` if desired.
+```python
+base_q.facets(return_type="polymer_entity", facets=Facet(name="Formula Weight", aggregation_type="histogram", attribute="rcsb_polymer_entity.formula_weight", interval=50, min_interval_population=1))
+```
+
+### Date Histogram Facets
+Similar to histogram facets, date histogram facetes build buckets over date values. For date histogram aggregations, we must specify `interval="year"`. Again, we may also specify `min_interval_population`.
+```python
+base_q.facets(facets=Facet(name="Release Date", aggregation_type="date_histogram", attribute="rcsb_accession_info.initial_release_date", interval="year", min_interval_population=1))
+```
+
+### Range Facets
+We can define the buckets ourselves by using range facets. In order to specify the ranges, we use the `Range` class. Note that the range includes the `start` value and excludes the `end` value (`include_lower` and `include_upper` should not be specified). If the `start` or `end` is omitted, the minimum or maximum boundaries will be used by default. The buckets should be provided as a list of `Range` objects to the `ranges` parameter.  
+```python
+base_q.facets(facets=Facet(name="Resolution Combined", aggregation_type="range", attribute="rcsb_entry_info.resolution_combined", ranges=[Range(start=None,end=2), Range(start=2, end=2.2), Range(start=2.2, end=2.4), Range(start=4.6, end=None)]))
+```
+
+### Date Range Facets
+Date range facets allow us to specify date values as bucket ranges, using [date math expressions](https://search.rcsb.org/#date-math-expressions).
+```python
+base_q.facets(facets=Facet(name="Release Date", aggregation_type="date_range", attribute="rcsb_accession_info.initial_release_date", ranges=[Range(start=None,end="2020-06-01||-12M"), Range(start="2020-06-01", end="2020-06-01||+12M"), Range(start="2020-06-01||+12M", end=None)]))
+```
+
+### Cardinality Facets 
+Cardinality facets return a single value: the count of distinct values returned for a given field. A `precision_threshold` (`<= 40000`, default value `40000`) may be specified.
+```python
+base_q.facets(facets=Facet(name="Organism Names Count", aggregation_type="cardinality", attribute="rcsb_entity_source_organism.ncbi_scientific_name"))
+```
+
+### Multidimensional Facets
+Complex, multi-dimensional aggregations are possible by specifying additional facets in the `nested_facets` parameter, as in the example below:
+```python
+f1 = Facet(name="Polymer Entity Types", aggregation_type="terms", attribute="rcsb_entry_info.selected_polymer_entity_types")
+f2 = Facet(name="Release Date", aggregation_type="date_histogram", attribute="rcsb_accession_info.initial_release_date", interval="year")
+base_q.facets(facets=Facet(name="Experimental Method", aggregation_type="terms", attribute="rcsb_entry_info.experimental_method", nested_facets=[f1, f2]))
+```
+
+### Filter Facets
+Filters allow us to filter documents that contribute to bucket count. Similar to queries, we can group several `TerminalFilter`s into a single `GroupFilter`. We can combine a filter with a facet using the `FilterFacet` class. Terminal filters should specify an `attribute` and `operator`, as well as possible a `value` and whether or not it should be a `negation` and/or `case_sensitive`. Group filters should specify a `logical_operator` (which should be either `"and"` or `"or"`) and a list of filters (`nodes`) that should be combined. Finally, the `FilterFacet` should be provided with a filter and a (list of) facet(s). Here are some examples:
+```python
+from rcsbsearchapi.search import TerminalFilter, GroupFilter, FilterFacet
+tf1 = TerminalFilter(attribute="rcsb_polymer_instance_annotation.type", operator="exact_match", value="CATH")
+tf2 = TerminalFilter(attribute="rcsb_polymer_instance_annotation.annotation_lineage.id", operator="in", value=["2.140.10.30", "2.120.10.80"])
+ff2 = FilterFacet(filters=tf2, facets=Facet("CATH Domains", "terms", "rcsb_polymer_instance_annotation.annotation_lineage.id", min_interval_population=1))
+ff1 = FilterFacet(filters=tf1, facets=ff2)
+base_q.facets("polymer_instance", ff1)
+
+tf1 = TerminalFilter(attribute="rcsb_struct_symmetry.kind", operator="exact_match", value="Global Symmetry", negation=False)
+f2 = Facet(name="ec_terms", aggregation_type="terms", attribute="rcsb_polymer_entity.rcsb_ec_lineage.id")
+f1 = Facet(name="sym_symbol_terms", aggregation_type="terms", attribute="rcsb_struct_symmetry.symbol", nested_facets=f2)
+ff = FilterFacet(filters=tf1, facets=f1)
+q1 = AttributeQuery("rcsb_assembly_info.polymer_entity_count", operator="equals", value=1)
+q2 = AttributeQuery("rcsb_assembly_info.polymer_entity_instance_count", operator="greater", value=1)
+q = q1 & q2
+q.facets("assembly", ff)
+
+tf1 = TerminalFilter(attribute="rcsb_polymer_entity_group_membership.aggregation_method", operator="exact_match", value="sequence_identity")
+tf2 = TerminalFilter(attribute="rcsb_polymer_entity_group_membership.similarity_cutoff", operator="equals", value=100)
+gf = GroupFilter(logical_operator="and", nodes=[tf1, tf2])
+ff = FilterFacet(filters=gf, facets=Facet("Distinct Protein Sequence Count", "cardinality", "rcsb_polymer_entity_group_membership.group_id"))
+base_q.facets("polymer_entity", ff)
+```

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -1,0 +1,44 @@
+# Attributes
+
+Attributes are pieces of information associated with a PDB structure that can be searched for or compared to a value using an [`AttributeQuery`](quickstart.md#getting-started)
+There are structure attributes and chemical attributes, which are both stored in `rcsb_attributes`. This can be imported as shown below:
+
+```python
+# you can import rcsb_attributes as attrs for a shorter name
+from rcsbsearchapi import rcsb_attributes as attrs
+```
+
+There are several helpful methods for searching for attributes and information related to them.
+
+###search()
+Given a string, this method will return an iterable of `Attr` objects with names that contain the given string. You can also use [regular expression (regex)](https://en.wikipedia.org/wiki/Regular_expression) strings.
+
+```python
+matching_attrs = attrs.search("author")
+
+for attr in matching_attrs:
+    print(attr)
+```
+
+###get_attribute_details()
+Given a full or partial attribute name, return a set of an attribute or associated attributes with attribute names, search service types, and descriptions.
+
+```python
+from rcsbsearchapi import rcsb_attributes as attrs
+
+# Use a full name to get details for a specific attribute
+print(attrs.get_attribute_details("rcsb_entity_source_organism.scientific_name"))
+
+# Use a partial name to get details of all attributes associate with that partial name
+# The below code prints out details for ".common_name", ".ncbi_parent_scientific_name", etc in addition to ".scientific_name"
+print(attrs.get_attribute_details("rcsb_entity_source_organism"))
+```
+
+###get_attribute_type()
+Given a full attribute name, return the search service type ("text" for structure attributes and "text_chem" for chemical attributes).
+
+```python
+from rcsbsearchapi import rcsb_attributes as attrs
+ 
+print(attrs.get_attribute_type("rcsb_entity_source_organism.scientific_name"))
+```

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -1,16 +1,15 @@
-# Attributes
+# Exploring Schema Attributes
 
-Attributes are pieces of information associated with a PDB structure that can be searched for or compared to a value using an [`AttributeQuery`](quickstart.md#getting-started)
-There are structure attributes and chemical attributes, which are both stored in `rcsb_attributes`. This can be imported as shown below:
+Attributes are pieces of information associated with a PDB structure that can be searched for or compared to a value using an [`AttributeQuery`](quickstart.md#getting-started). There are [structure attributes](https://search.rcsb.org/structure-search-attributes.html) and [chemical attributes](https://search.rcsb.org/chemical-search-attributes.html), which are both stored in `rcsb_attributes`. This can be imported as shown below:
 
 ```python
-# you can import rcsb_attributes as attrs for a shorter name
+# import rcsb_attributes as attrs for a shorter name
 from rcsbsearchapi import rcsb_attributes as attrs
 ```
 
-There are several helpful methods for searching for attributes and information related to them.
+There are several helpful methods to search for attribute names or explore other information related to attributes.
 
-###search()
+### search()
 Given a string, this method will return an iterable of `Attr` objects with names that contain the given string. You can also use [regular expression (regex)](https://en.wikipedia.org/wiki/Regular_expression) strings.
 
 ```python
@@ -20,8 +19,8 @@ for attr in matching_attrs:
     print(attr)
 ```
 
-###get_attribute_details()
-Given a full or partial attribute name, return a set of an attribute or associated attributes with attribute names, search service types, and descriptions.
+### get_attribute_details()
+Given a full or partial attribute name, return a set of an `Attr` or associated `Attr`s with attribute names, search service types, and descriptions.
 
 ```python
 from rcsbsearchapi import rcsb_attributes as attrs
@@ -29,12 +28,12 @@ from rcsbsearchapi import rcsb_attributes as attrs
 # Use a full name to get details for a specific attribute
 print(attrs.get_attribute_details("rcsb_entity_source_organism.scientific_name"))
 
-# Use a partial name to get details of all attributes associate with that partial name
+# Use a partial name to get the details of all attributes associated with that name
 # The below code prints out details for ".common_name", ".ncbi_parent_scientific_name", etc in addition to ".scientific_name"
 print(attrs.get_attribute_details("rcsb_entity_source_organism"))
 ```
 
-###get_attribute_type()
+### get_attribute_type()
 Given a full attribute name, return the search service type ("text" for structure attributes and "text_chem" for chemical attributes).
 
 ```python

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ maxdepth: 2
 ---
 quickstart.md
 queries.md
+attributes.md
 additional_examples.md
 api.rst
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ maxdepth: 2
 ---
 quickstart.md
 queries.md
+additional_examples.md
 api.rst
 ```
 

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -1,15 +1,20 @@
 # Queries
 
+## Constructing and Executing Queries
 Two syntaxes are available for constructing queries: an "operator" API using python's
 comparators, and a "fluent" API where terms are chained together. Which to use is a
 matter of preference, and both construct the same query object.
 
-## Operator syntax
+### Operator syntax
 
 Searches are built up from a series of `Terminal` nodes, which compare structural
 attributes to some search value. In the operator syntax, python's comparator
 operators are used to construct the comparison. The operators are overloaded to
 return `Terminal` objects for the comparisons.
+
+Here is an example from the [RCSB PDB Search API](http://search.rcsb.org/#search-example-1) page, using the operator syntax. 
+This query finds symmetric dimers having a twofold rotation with the DNA-binding
+domain of a heat-shock transcription factor.
 ```python
 from rcsbsearchapi.search import TextQuery
 from rcsbsearchapi import rcsb_attributes as attrs
@@ -20,13 +25,16 @@ q2 = attrs.rcsb_struct_symmetry.symbol == "C2"
 q3 = attrs.rcsb_struct_symmetry.kind == "Global Symmetry"
 q4 = attrs.rcsb_entry_info.polymer_entity_count_DNA >= 1
 ```
-Attributes are available from the rcsb_attributes object and can be tab-completed.
+Attributes are available from the rcsb_attributes object and can be tab-completed. 
 They can additionally be constructed from strings using the `Attr(attribute)`
-constructor. For a full list of attributes, please refer to the [RCSB PDB schema](http://search.rcsb.org/rcsbsearch/v2/metadata/schema).
+constructor. 
+
+For a full list of attributes, please refer to the [RCSB PDB schema](http://search.rcsb.org/rcsbsearch/v2/metadata/schema). 
 
 `Terminal`s are combined into `Group`s using python's bitwise operators. This is
 analogous to how bitwise operators act on python `set` objects. The operators are
 lazy and won't perform the search until the query is executed.
+
 ```python
 query = q1 & (q2 & q3 & q4)  # AND of all queries
 ```
@@ -36,20 +44,33 @@ and general negation by transforming the query.
 
 Queries are executed by calling them as functions. They return an iterator of result
 identifiers.
+
 ```python
-results = set(query())
+# Call the query to execute it
+results = query()
+
+for id in results:
+    print(id)
 ```
+
 By default, the query will return "entry" results (PDB IDs). It is also possible to
 query other types of results (see [return-types](http://search.rcsb.org/#return-type)
 for options):
+
 ```python
-assemblies = set(query("assembly"))
+results = query(return_type="assembly")  # set return_type to "assembly"
+
+for assemblyid in results:
+    print(assemblyid)
 ```
 ### Fluent syntax
 
 The operator syntax is great for simple queries, but requires parentheses or
 temporary variables for complex nested queries. In these cases the fluent syntax may
 be clearer. Queries are built up by appending operations sequentially.
+
+Here is the same example using the fluent syntax
+
 ```python
 from rcsbsearchapi.search import TextQuery, AttributeQuery, Attr
 
@@ -57,46 +78,71 @@ from rcsbsearchapi.search import TextQuery, AttributeQuery, Attr
 results = TextQuery("heat-shock transcription factor").and_(
     # Add attribute node as fully-formed AttributeQuery
     AttributeQuery(attribute="rcsb_struct_symmetry.symbol", operator="exact_match", value="C2") \
+
     # Add attribute node as Attr with chained operations
-    .and_(Attr("rcsb_struct_symmetry.kind")).exact_match("Global Symmetry") \
+    # Setting type to "text" specifies that it's a Structure Attribute
+    .and_(Attr(attribute="rcsb_struct_symmetry.kind", type="text")).exact_match("Global Symmetry") \
+
     # Add attribute node by name (converted to Attr) with chained operations
     .and_("rcsb_entry_info.polymer_entity_count_DNA").greater_or_equal(1)
-    ).exec("assembly")
+    ).exec(return_type="assembly")
 
 # Exec produces an iterator of IDs
 for assemblyid in results:
     print(assemblyid)
 ```
+
 ### Structural Attribute Search and Chemical Attribute Search Combination
 
-Grouping of a Structural Attribute query and Chemical Attribute query is permitted as long as grouping is done correctly and search services are specified accordingly. More details on attributes that are available for text searches can be found on the [RCSB PDB Search API](https://search.rcsb.org/#search-attributes) page.
+Grouping of a Structural Attribute query and Chemical Attribute query is permitted. As Structure Attributes and Chemical Attributes are almost all unique, the package is able to determine the search service required. For attributes that are both Structure and Chemical Attributes (`rcsb_id`), specifying a search service is required. More details on attributes that are available for text searches can be found on the [RCSB PDB Search API](https://search.rcsb.org/#search-attributes) page.
+
 ```python
-from rcsbsearchapi.const import CHEMICAL_ATTRIBUTE_SEARCH_SERVICE, STRUCTURE_ATTRIBUTE_SEARCH_SERVICE
 from rcsbsearchapi.search import AttributeQuery
 
-# By default, service is set to "text" for structural attribute search
-q1 = AttributeQuery("exptl.method", "exact_match", "electron microscopy",
-                    STRUCTURE_ATTRIBUTE_SEARCH_SERVICE # this constant specifies "text" service
-                    )
-
-# Need to specify chemical attribute search service - "text_chem"
-q2 = AttributeQuery("drugbank_info.brand_names", "contains_phrase", "tylenol",
-                    CHEMICAL_ATTRIBUTE_SEARCH_SERVICE # this constant specifies "text_chem" service
-                    )
+q1 = AttributeQuery(
+    attribute="exptl.method",
+    operator="exact_match",
+    value="electron microscopy"
+)
+q2 = AttributeQuery(
+    attribute="drugbank_info.brand_names",
+    operator="contains_phrase",
+    value="tylenol"
+)
 
 query = q1 & q2 # combining queries
 
 list(query())
 ```
+
+```python
+# "rcsb_id" is a Structure Attribute and Chemical Attribute, so search service must be specified
+q1 = AttributeQuery(
+    attribute="rcsb_id",
+    operator="exact_match",
+    value="4HHB",
+    service="text"  # "text" specifies Structure Attribute search
+)
+list(q1())
+
+q2 = AttributeQuery(
+    attribute="rcsb_id",
+    operator="exact_match",
+    value="HEM",
+    service="text_chem"  # "text_chem" specifies Chemical Attribute search
+)
+list(q2())
+```
+
 ### Computed Structure Models
 
 The [RCSB PDB Search API](https://search.rcsb.org/#results_content_type) page provides information on how to include Computed Structure Models (CSMs) into a search query. Here is a code example below. This query returns IDs for experimental and computed structure models associated with "hemoglobin". Queries for *only* computed models or *only* experimental models can also be made (default).
 ```python
 from rcsbsearchapi.search import TextQuery
 
-q1 = TextQuery("hemoglobin")
+q1 = TextQuery(value="hemoglobin")
 
-# add parameter as a list with either "computational" or "experimental" or both as list values
+# add parameter as a list with either "computational" or "experimental" or both
 q2 = q1(return_content_type=["computational", "experimental"])
 
 list(q2)
@@ -111,430 +157,50 @@ More information on return types can be found in the
 ```python
 from rcsbsearchapi.search import AttributeQuery
 
-q1 = AttributeQuery("rcsb_entry_container_identifiers.entry_id", "in", ["4HHB"]) # query for 4HHB deoxyhemoglobin
+# query for 4HHB deoxyhemoglobin
+q1 = AttributeQuery(
+    attribute="rcsb_entry_container_identifiers.entry_id",
+    operator="in",
+    value=["4HHB"]
+)
 
 # Polymer entities
-for poly in q1("polymer_entity"): # include return type as a string parameter for query object
+for poly in q1(return_type="polymer_entity"):
     print(poly)
     
 # Non-polymer entities
-for nonPoly in q1("non_polymer_entity"):
+for nonPoly in q1(return_type="non_polymer_entity"):
     print(nonPoly)
     
 # Polymer instances
-for polyInst in q1("polymer_instance"):
+for polyInst in q1(return_type="polymer_instance"):
     print(polyInst)
     
 # Molecular definitions
-for mol in q1("mol_definition"):
+for mol in q1(return_type="mol_definition"):
     print(mol)
 ```
-### Counting Results
+## Counting Results
 
 If only the number of results is desired, the count function can be used. This query returns the number of experimental models associated with "hemoglobin".
 ```python
 from rcsbsearchapi.search import TextQuery
 
-q1 = TextQuery("hemoglobin")
+q1 = TextQuery(value="hemoglobin")
 
-# N.B., Just as shown above for `query()`, `return_type` and `return_content_type` can also be specified as parameters to `count()`
+# As for `query()`, `return_type` and `return_content_type` can be parameters to `count()`
 q1.count()
 ```
-### Obtaining Scores for Results
+
+## Result Verbosity
 
 Results can be returned alongside additional metadata, including result scores. To return this metadata, set the `results_verbosity` parameter to "verbose" (all metadata), "minimal" (scores only), or "compact" (default, no metadata). If set to "verbose" or "minimal", results will be returned as a list of dictionaries. For example, here we get all experimental models associated with "hemoglobin", along with their scores.
 ```python
 from rcsbsearchapi.search import TextQuery
 
-q1 = TextQuery("hemoglobin")
+q1 = TextQuery(value="hemoglobin")
 for idscore in list(q1(results_verbosity="minimal")):
     print(idscore)
-```
-### Protein Sequence Search Example
-
-Below is an example from the [RCSB PDB Search API](https://search.rcsb.org/#search-example-3) page, 
-using the sequence search function.
-This query finds macromolecular PDB entities that share 90% sequence identity with
-GTPase HRas protein from *Gallus gallus* (*Chicken*).
-```python
-from rcsbsearchapi.search import SequenceQuery
-
-# Use SequenceQuery class and add parameters
-results = SequenceQuery("MTEYKLVVVGAGGVGKSALTIQLIQNHFVDEYDPTIEDSYRKQVVIDGET" +
-                        "CLLDILDTAGQEEYSAMRDQYMRTGEGFLCVFAINNTKSFEDIHQYREQI" +
-                        "KRVKDSDDVPMVLVGNKCDLPARTVETRQAQDLARSYGIPYIETSAKTRQ" +
-                        "GVEDAFYTLVREIRQHKLRKLNPPDESGPGCMNCKCVIS", 1, 0.9)
-    
-# results("polymer_entity") produces an iterator of IDs with return type - polymer entities
-for polyid in results("polymer_entity"):
-    print(polyid)
-```
-### Sequence Motif Search Example
-
-Below is an example from the [RCSB PDB Search API](https://search.rcsb.org/#search-example-6) page,
-using the sequence motif search function. 
-This query retrives occurences of the His2/Cys2 Zinc Finger DNA-binding domain as
-represented by its PROSITE signature. 
-```python
-from rcsbsearchapi.search import SeqMotifQuery
-
-# Use SeqMotifQuery class and add parameters
-results = SeqMotifQuery("C-x(2,4)-C-x(3)-[LIVMFYWC]-x(8)-H-x(3,5)-H.",
-                        pattern_type="prosite",
-                        sequence_type="protein")
-
-# results("polymer_entity") produces an iterator of IDs with return type - polymer entities
-for polyid in results("polymer_entity"):
-    print(polyid)
-```
-
-You can also use a regular expression (RegEx) to make a sequence motif search.
-As an example, here is a query for the zinc finger motif that binds Zn in a DNA-binding domain:
-```python
-from rcsbsearchapi.search import SeqMotifQuery
-
-results = SeqMotifQuery("C.{2,4}C.{12}H.{3,5}H", pattern_type="regex", sequence_type="protein")
-
-for polyid in results("polymer_entity"):
-    print(polyid)
-```
-
-You can use a standard amino acid sequence to make a sequence motif search. 
-X can be used to allow any amino acid in that position. 
-As an example, here is a query for SH3 domains:
-```python
-from rcsbsearchapi.search import SeqMotifQuery
-
-# By default, the pattern_type argument is "simple" and the sequence_type argument is "protein".
-results = SeqMotifQuery("XPPXP")  # X is used as a "variable residue" and can be any amino acid. 
-
-for polyid in results("polymer_entity"):
-    print(polyid)
-```
-
-All 3 of these pattern types can be used to search for DNA and RNA sequences as well.
-Demonstrated are 2 queries, one DNA and one RNA, using the simple pattern type:
-```python
-from rcsbsearchapi.search import SeqMotifQuery
-
-# DNA query: this is a query for a T-Box.
-dna = SeqMotifQuery("TCACACCT", sequence_type="dna")
-
-print("DNA results:")
-for polyid in dna("polymer_entity"):
-    print(polyid)
-
-# RNA query: 6C RNA motif
-rna = SeqMotifQuery("CCCCCC", sequence_type="rna")
-print("RNA results:")
-for polyid in rna("polymer_entity"):
-    print(polyid)
-```
-### Structure Similarity Query Example
-
-The PDB archive can be queried using the 3D shape of a protein structure. To perform this query, 3D protein structure data must be provided as an input or parameter, A chain ID or assembly ID must be specified, whether the input structure data should be compared to Assemblies or Polymer Entity Instance (Chains) is required, and defining the search type as either strict or relaxed is required. More information on how Structure Similarity Queries work can be found on the [RCSB PDB Structure Similarity Search](https://www.rcsb.org/docs/search-and-browse/advanced-search/structure-similarity-search) page.
-```python
-from rcsbsearchapi.search import StructSimilarityQuery
-
-# Basic query: querying using entry ID and default values assembly ID "1", operator "strict", and target search space "Assemblies"
-q1 = StructSimilarityQuery(entry_id="4HHB")
-
-# Same example but with parameters explicitly specified
-q1 = StructSimilarityQuery(structure_search_type="entry_id",
-                           entry_id="4HHB",
-                           structure_input_type="assembly_id",
-                           assembly_id="1",
-                           operator="strict_shape_match",
-                           target_search_space="assembly"
-                           )
-for id in q1("assembly"):
-    print(id)
-```
-Below is a more complex example that utilizes chain ID, relaxed search operator, and polymer entity instance or target search space. Specifying whether the input structure
-type is chain id or assembly id is very important. For example, specifying chain ID as the input structure type but inputting an assembly ID can lead to
-an error.
-```python
-from rcsbsearchapi.search import StructSimilarityQuery
-
-# More complex query with entry ID value "4HHB", chain ID "B", operator "relaxed", and target search space "Chains"
-q2 = StructSimilarityQuery(structure_search_type="entry_id",
-                                   entry_id="4HHB",
-                                   structure_input_type="chain_id",
-                                   chain_id="B",
-                                   operator="relaxed_shape_match",
-                                   target_search_space="polymer_entity_instance")
-list(q2())
-```
-Structure similarity queries also allow users to upload a file from their local computer or input a file url from the website to query the PDB archive for similar proteins. The file represents a target protein structure in the file formats "cif", "bcif", "pdb", "cif.gz", or "pdb.gz". If a user wants to use a file url for queries, the user must specify the structure search type, the value (being the url), and the file format of the file. This is also the same case for file upload, except the value is the absolute path leading to the file that is in the local machine. An example for file url is below for 4HHB (hemoglobin).
-```python
-from rcsbsearchapi.search import StructSimilarityQuery
-
-q3 = StructSimilarityQuery(structure_search_type="file_url",
-                           file_url="https://files.rcsb.org/view/4HHB.cif",
-                           file_format="cif")
-list(q3())
-
-# If you want to upload your own structure file for similarity search, you can do so by using the `file_path` parameter:
-q4 = StructSimilarityQuery(structure_search_type="file_upload",
-                           file_path="/PATH/TO/FILE.cif",  # specify local model file path
-                           file_format="cif")
-list(q4())
-```
-
-### Structure Motif Query Examples
-
-The PDB Archive can also be queried by using a "motif" found in these 3D structures. To perform this type of query, an entry_id or a file URL/path must be provided, along with residues (which are parts of 3D structures.) This is the bare minimum needed to make a search, but there are lots of other parameters that can be added to a Structure Motif Query (see [full search schema](https://search.rcsb.org/redoc/index.html)).
-
-To make a Structure Motif Query, you must first define anywhere from 2-10 "residues" that will be used in the query. Each individual residue has a Chain ID, Operator, Residue Number, and Exchanges (optional) that can be declared in that order using positonal arguments, or using the "chain_id", "struct_oper_id", and "label_seq_id" to define what parameter you are passing through. All 3 of the required parameters must be included, or the package will throw an AssertionError. 
-
-Each residue can only have a maximum of 4 Exchanges, and each query can only have 16 exchanges total. Violating any of these rules will cause the package to throw an AssertionError. 
-
-Examples of how to instantiate Residues can be found below. These can then be put into a list and passed through to a Structure Motif Query.
-```python
-from rcsbsearchapi.search import StructureMotifResidue
-
-# construct a Residue with a Chain ID of A, an operator of 1, a residue 
-# number of 192, and Exchanges of "LYS" and "HIS"
-Res1 = StructureMotifResidue("A", "1", 192, ["LYS", "HIS"])
-# as for what is a valid "Exchange", the package provides these as a literal,
-# and they should be type checked. 
-
-# you can also specify the arguments:
-# this query is the same as above. 
-Res2 = StructureMotifResidue(struct_oper_id="1", chain_id="A", exchanges=["LYS", "HIS"], label_seq_id=192)
-
-# after delcaring a minimum of 2 and as many as 10 residues, they can be passed into a list for use in the query itself:
-Res3 = StructureMotifResidue("A", "1", 162)  # exchanges are optional
-
-ResList = [Res1, Res3]
-```
-From there, these Residues can be used in a query. As stated before, you can only include 2 - 10 residues in a query. If you fail to provide residues for a query, or provide the wrong amount, the package will throw a ValueError. 
-
-For a Structure Motif Query using an entry_id, the only other necessary value that must be passed into the query is the residue list. The default type of query is an entry_id query. 
-
-As this type of query has a lot of optional parameters, do *not* use positional arguments as more than likely an error will occur. 
-
-Below is an example of a basic entry_id Structure Motif Query, with the residues declared earlier:
-```python
-from rcsbsearchapi.search import StructMotifQuery
-
-q1 = StructMotifQuery(entry_id="2MNR", residue_ids=ResList)
-list(q1())
-```
-Like with Structure Similarity Queries, a file url or filepath can also be provided to the program. These can take the place of an entry_id. 
-
-For a file url query, you *must* provide both a valid file URL (a string), and the file's file extension (also as a string). Failure to provide these elements correctly will cause the package to throw an AssertionError. 
-
-Below is an example of the same query as above, only this time providing a file url:
-```python
-link = "https://files.rcsb.org/view/2MNR.cif"
-q2 = StructMotifQuery(structure_search_type="file_url", url=link, file_extension="cif", residue_ids=ResList)
-# structure_search_type MUST be provided. A mismatched query type will cause an error. 
-list(q2())
-```
-Like with Structure Similarity Queries, a filepath to a file may also be provided. This file must be a valid file accepted by the search API. A file extension must also be provided with the file upload. 
-
-The query would look something like this:
-```python
-filepath = "/absolute/path/to/file.cif"
-q3 = StructMotifQuery(structure_search_type="file_upload", file_path=filepath, file_extension="cif", residue_ids=ResList)
-
-list(q3())
-```
-There are many additional parameters that Structure Motif Query supports. These include a variety of features such as backbone distance tolerance, side chain distance tolerance, angle tolerance, RMSD cutoff, limits (stop searching after this many hits), atom pairing schemes, motif pruning strategy, allowed structures, and excluded structures. These can be mixed and matched as needed to make accurate and useful queries. All of these have some default value which is used when a parameter isn't provided. These parameters conform to the defaults used by the Search API. 
-
-Below will demonstrate how to define these parameters using non-positional arguments:
-```python
-# specifying backbone distance tolerance: 0-3, default is 1
-# allowed backbone distance tolerance in Angstrom. 
-backbone = StructMotifQuery(entry_id="2MNR", backbone_distance_tolerance=2, residue_ids=ResList)
-list(backbone())
-
-# specifying sidechain distance tolerance: 0-3, default is 1
-# allowed side-chain distance tolerance in Angstrom.
-sidechain = StructMotifQuery(entry_id="2MNR", side_chain_distance_tolerance=2, residue_ids=ResList)
-list(sidechain())
-
-# specifying angle tolerance: 0-3, default is 1
-# allowed angle tolerance in multiples of 20 degrees. 
-angle = StructMotifQuery(entry_id="2MNR", angle_tolerance=2, residue_ids=ResList)
-list(angle())
-
-# specifying RMSD cutoff: >=0, default is 2
-# Threshold above which hits will be filtered by RMSD
-rmsd = StructMotifQuery(entry_id="2MNR", rmsd_cutoff=1, residue_ids=ResList)
-list(rmsd())
-
-# specifying limit: >=0, default excluded
-# Stop accepting results after this many hits. 
-limit = StructMotifQuery(entry_id="2MNR", limit=100, residue_ids=ResList)
-list(limit())
-
-# specifying atom pairing scheme, default = "SIDE_CHAIN"
-# ENUM: "ALL", "BACKBONE", "SIDE_CHAIN", "PSUEDO_ATOMS"
-# this is typechecked by a literal. 
-# Which atoms to consider to compute RMSD scores and transformations. 
-atom = StructMotifQuery(entry_id="2MNR", atom_pairing_scheme="ALL", residue_ids=ResList)
-list(atom())
-
-# specifying motif pruning strategy, default = "KRUSKAL"
-# ENUM: "NONE", "KRUSKAL"
-# this is typechecked by a literal in the package. 
-# Specifies how many query motifs are "pruned". KRUSKAL leads to less stringent queries, and faster results.
-pruning = StructMotifQuery(entry_id="2MNR", motif_pruning_strategy="NONE", residue_ids=ResList)
-list(pruning())
-
-# specifying allowed structures, default excluded
-# specify the structures you wish to allow in the return result. As an example,
-# we could only allow the results from the limited query we ran earlier. 
-allowed = StructMotifQuery(entry_id="2MNR", allowed_structures=list(limit()), residue_ids=ResList)
-list(allowed())
-
-# specifying structures to exclude, default excluded
-# specify structures to exclude from a query. We could, for example,
-# exclude the results of the previous allowed query. 
-excluded = StructMotifQuery(entry_id="2MNR", excluded_structures=list(allowed()), residue_ids=ResList)
-list(excluded())
-```
-The Structure Motif Query can be used to make some very specific queries. Below is an example of a query that retrives occurances of the enolase superfamily, a group of proteins diverse in sequence and structure that are all capable of abstracting a proton from a carboxylic acid. Position-specific exchanges are crucial to represent this superfamily accurately.
-```python
-Res1 = StructureMotifResidue("A", "1", 162, ["LYS", "HIS"])
-Res2 = StructureMotifResidue("A", "1", 193)
-Res3 = StructureMotifResidue("A", "1", 219)
-Res4 = StructureMotifResidue("A", "1", 245, ["GLU", "ASP", "ASN"])
-Res5 = StructureMotifResidue("A", "1", 295, ["HIS", "LYS"])
-
-ResList = [Res1, Res2, Res3, Res4, Res5]
-
-query = StructMotifQuery(entry_id="2MNR", residue_ids=ResList)
-
-list(query())
-```
-### Chemical Similarity Query
-
-When you have unique chemical information (e.g., a chemical formula or descriptor) you can use this information to find chemical components (e.g., drugs, inhibitors, modified residues, or building blocks such as amino acids, nucleotides, or sugars), so that it is similar to the formula or descriptor used in the query (perhaps one or two atoms/groups are different), is part of a larger molecule (i.e., the specified formula/descriptor is a substructure), or is exactly or very closely matches the formula or descriptor used in the query. 
-
-The search can also be used to identify PDB structures that include the chemical component(s) which match or are similar to the query. These structures can then be examined to learn about the interactions of the component within the structure. More information on Chemical Similarity Queries can be found on the [RCSB PDB Chemical Similarity Search](https://www.rcsb.org/docs/search-and-browse/advanced-search/chemical-similarity-search) page.
-
-To do a Chemical Similarity query, you must first specify one of two possible query options which are formula and descriptors. Formula allows queries to be made by providing a chemical formula. Descriptors allow you to search by chemical notations for example. Each Query option has its own distinct set of parameters, but both options require a value.
-
-The formula query option comes with a match subset parameter which allows users to search chemical components whose formula exactly match the query or matches any portion of the query. The descriptor query option comes with a descriptor type parameter and match type parameter. The descriptor type parameter specifies what type of descriptor the input value is. There are two options which are SMILES (Simplified Molecular Input Line Entry Specification) and InChI (International Chemical Identifier). The match type parameter has six options which are Similar Ligands (Quick Screen), Similar Ligands (Stereospecific), Similar Ligands (including Stereoisomers), Substructure (Stereospecific), Substructure (including Stereoisomers), and Exact match.
-
-When doing Chemical Similarity Queries in this tool, it is important to note that by default the query option is set to formula and match subset is set to False. An example of how that looks like is below.
-```python
-from rcsbsearchapi.search import ChemSimilarityQuery
-
-# Basic query with default values: query type = formula and match subset = False
-q1 = ChemSimilarityQuery(value="C12 H17 N4 O S")
-
-# Same example but with all the parameters listed
-q1 = ChemSimilarityQuery(value="C12 H17 N4 O S",
-                         query_type="formula",
-                         match_subset=False)
-list(q1())
-```
-Below is are two examples of using query option descriptor. Both descriptor type parameters are also used.
-```python
-from rcsbsearchapi.search import ChemSimilarityQuery
-
-# Query with type = descriptor, descriptor type = SMILES, match type = similar ligands (sterospecific) or graph-relaxed-stereo
-q2 = ChemSimilarityQuery(value="Cc1c(sc[n+]1Cc2cnc(nc2N)C)CCO",
-                         query_type="descriptor",
-                         descriptor_type="SMILES",
-                         match_type="graph-relaxed-stereo")
-list(q2())
-```
-```python
-from rcsbsearchapi.search import ChemSimilarityQuery
-
-# Query with type = descriptor, descriptor type = InChI, match type = substructure (sterospecific) or sub-struct-graph-relaxed-stereo
-q3 = ChemSimilarityQuery(value="InChI=1S/C13H10N2O4/c16-10-6-5-9(11(17)14-10)15-12(18)7-3-1-2-4-8(7)13(15)19/h1-4,9H,5-6H2,(H,14,16,17)/t9-/m0/s1",
-                         query_type="descriptor",
-                         descriptor_type="InChI",
-                         match_type="sub-struct-graph-relaxed-stereo")
-list(q3())
-```
-### Faceted Query Examples
-In order to group and perform calculations and statistics on PDB data by using a simple search query, you can use a faceted query (or facets). Facets arrange search results into categories (buckets) based on the requested field values. More information on Faceted Queries can be found [here](https://search.rcsb.org/#using-facets). All facets should be provided with `name`, `aggregation_type`, and `attribute` values. Depending on the aggregation type, other parameters must also be specified. The `facets()` function runs the query `q` using the specified facet(s), and returns a list of dictionaries:
-```python
-from rcsbsearchapi.search import AttributeQuery, Facet, Range
-
-q = AttributeQuery("rcsb_accession_info.initial_release_date", operator="greater", value="2019-08-20")
-q.facets(facets=Facet(name="Methods", aggregation_type="terms", attribute="exptl.method"))
-```
-
-#### Term Facets
-Terms faceting is a multi-bucket aggregation where buckets are dynamically built - one per unique value. We can specify the minimum count (`>= 0`) for a bucket to be returned using the parameter `min_interval_population` (default value `1`). We can also control the number of buckets returned (`<= 65336`) using the parameter `max_num_intervals` (default value `65336`).
-```python
-# This is the default query, used by the RCSB Search API when no query is explicitly specified.
-# This default query will be used for most of the examples found below for faceted queries.
-base_q = AttributeQuery("rcsb_entry_info.structure_determination_methodology", operator="exact_match", value="experimental") 
-
-base_q.facets(facets=Facet(name="Journals", aggregation_type="terms", attribute="rcsb_primary_citation.rcsb_journal_abbrev", min_interval_population=1000))
-```
-
-#### Histogram Facets
-Histogram facets build fixed-sized buckets (intervals) over numeric values. The size of the intervals must be specified in the parameter `interval`. We can also specify `min_interval_population` if desired.
-```python
-base_q.facets(return_type="polymer_entity", facets=Facet(name="Formula Weight", aggregation_type="histogram", attribute="rcsb_polymer_entity.formula_weight", interval=50, min_interval_population=1))
-```
-
-#### Date Histogram Facets
-Similar to histogram facets, date histogram facetes build buckets over date values. For date histogram aggregations, we must specify `interval="year"`. Again, we may also specify `min_interval_population`.
-```python
-base_q.facets(facets=Facet(name="Release Date", aggregation_type="date_histogram", attribute="rcsb_accession_info.initial_release_date", interval="year", min_interval_population=1))
-```
-
-#### Range Facets
-We can define the buckets ourselves by using range facets. In order to specify the ranges, we use the `Range` class. Note that the range includes the `start` value and excludes the `end` value (`include_lower` and `include_upper` should not be specified). If the `start` or `end` is omitted, the minimum or maximum boundaries will be used by default. The buckets should be provided as a list of `Range` objects to the `ranges` parameter.  
-```python
-base_q.facets(facets=Facet(name="Resolution Combined", aggregation_type="range", attribute="rcsb_entry_info.resolution_combined", ranges=[Range(start=None,end=2), Range(start=2, end=2.2), Range(start=2.2, end=2.4), Range(start=4.6, end=None)]))
-```
-
-#### Date Range Facets
-Date range facets allow us to specify date values as bucket ranges, using [date math expressions](https://search.rcsb.org/#date-math-expressions).
-```python
-base_q.facets(facets=Facet(name="Release Date", aggregation_type="date_range", attribute="rcsb_accession_info.initial_release_date", ranges=[Range(start=None,end="2020-06-01||-12M"), Range(start="2020-06-01", end="2020-06-01||+12M"), Range(start="2020-06-01||+12M", end=None)]))
-```
-
-#### Cardinality Facets 
-Cardinality facets return a single value: the count of distinct values returned for a given field. A `precision_threshold` (`<= 40000`, default value `40000`) may be specified.
-```python
-base_q.facets(facets=Facet(name="Organism Names Count", aggregation_type="cardinality", attribute="rcsb_entity_source_organism.ncbi_scientific_name"))
-```
-
-#### Multidimensional Facets
-Complex, multi-dimensional aggregations are possible by specifying additional facets in the `nested_facets` parameter, as in the example below:
-```python
-f1 = Facet(name="Polymer Entity Types", aggregation_type="terms", attribute="rcsb_entry_info.selected_polymer_entity_types")
-f2 = Facet(name="Release Date", aggregation_type="date_histogram", attribute="rcsb_accession_info.initial_release_date", interval="year")
-base_q.facets(facets=Facet(name="Experimental Method", aggregation_type="terms", attribute="rcsb_entry_info.experimental_method", nested_facets=[f1, f2]))
-```
-
-#### Filter Facets
-Filters allow us to filter documents that contribute to bucket count. Similar to queries, we can group several `TerminalFilter`s into a single `GroupFilter`. We can combine a filter with a facet using the `FilterFacet` class. Terminal filters should specify an `attribute` and `operator`, as well as possible a `value` and whether or not it should be a `negation` and/or `case_sensitive`. Group filters should specify a `logical_operator` (which should be either `"and"` or `"or"`) and a list of filters (`nodes`) that should be combined. Finally, the `FilterFacet` should be provided with a filter and a (list of) facet(s). Here are some examples:
-```python
-from rcsbsearchapi.search import TerminalFilter, GroupFilter, FilterFacet
-tf1 = TerminalFilter(attribute="rcsb_polymer_instance_annotation.type", operator="exact_match", value="CATH")
-tf2 = TerminalFilter(attribute="rcsb_polymer_instance_annotation.annotation_lineage.id", operator="in", value=["2.140.10.30", "2.120.10.80"])
-ff2 = FilterFacet(filters=tf2, facets=Facet("CATH Domains", "terms", "rcsb_polymer_instance_annotation.annotation_lineage.id", min_interval_population=1))
-ff1 = FilterFacet(filters=tf1, facets=ff2)
-base_q.facets("polymer_instance", ff1)
-
-tf1 = TerminalFilter(attribute="rcsb_struct_symmetry.kind", operator="exact_match", value="Global Symmetry", negation=False)
-f2 = Facet(name="ec_terms", aggregation_type="terms", attribute="rcsb_polymer_entity.rcsb_ec_lineage.id")
-f1 = Facet(name="sym_symbol_terms", aggregation_type="terms", attribute="rcsb_struct_symmetry.symbol", nested_facets=f2)
-ff = FilterFacet(filters=tf1, facets=f1)
-q1 = AttributeQuery("rcsb_assembly_info.polymer_entity_count", operator="equals", value=1)
-q2 = AttributeQuery("rcsb_assembly_info.polymer_entity_instance_count", operator="greater", value=1)
-q = q1 & q2
-q.facets("assembly", ff)
-
-tf1 = TerminalFilter(attribute="rcsb_polymer_entity_group_membership.aggregation_method", operator="exact_match", value="sequence_identity")
-tf2 = TerminalFilter(attribute="rcsb_polymer_entity_group_membership.similarity_cutoff", operator="equals", value=100)
-gf = GroupFilter(logical_operator="and", nodes=[tf1, tf2])
-ff = FilterFacet(filters=gf, facets=Facet("Distinct Protein Sequence Count", "cardinality", "rcsb_polymer_entity_group_membership.group_id"))
-base_q.facets("polymer_entity", ff)
 ```
 
 ## Sessions

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -142,7 +142,9 @@ list(q2())
 ```
 
 ### Computed Structure Models
-The [RCSB PDB Search API](https://search.rcsb.org/#results_content_type) page provides information on how to include Computed Structure Models (CSMs) into a search query. Here is a code example below. This query returns IDs for experimental and computed structure models associated with "hemoglobin". Queries for *only* computed models or *only* experimental models can also be made (default).
+The [RCSB PDB Search API](https://search.rcsb.org/#results_content_type) page provides information on how to include Computed Structure Models (CSMs) into a search query. Here is a code example below.
+
+This query returns IDs for experimental and computed structure models associated with "hemoglobin". Queries for *only* computed models or *only* experimental models can also be made (default).
 ```python
 from rcsbsearchapi.search import TextQuery
 
@@ -156,8 +158,10 @@ list(q2)
 
 ### Return Types and Attribute Search
 A search query can return different result types when a return type is specified. 
-Below are examples on specifying return types Polymer Entities,
-Non-polymer Entities, Polymer Instances, and Molecular Definitions, using a Structure Attribute query. 
+Below are Structure Attribute query examples specifying return types Polymer Entities,
+Non-polymer Entities, Polymer Instances, and Molecular Definitions. 
+
+
 More information on return types can be found in the 
 [RCSB PDB Search API](https://search.rcsb.org/#building-search-request) page.
 ```python
@@ -186,6 +190,7 @@ for polyInst in q1(return_type="polymer_instance"):
 for mol in q1(return_type="mol_definition"):
     print(mol)
 ```
+
 ## Counting Results
 If only the number of results is desired, the count function can be used. This query returns the number of experimental models associated with "hemoglobin".
 ```python
@@ -198,7 +203,10 @@ q1.count()
 ```
 
 ## Result Verbosity
-Results can be returned alongside additional metadata, including result scores. To return this metadata, set the `results_verbosity` parameter to "verbose" (all metadata), "minimal" (scores only), or "compact" (default, no metadata). If set to "verbose" or "minimal", results will be returned as a list of dictionaries. For example, here we get all experimental models associated with "hemoglobin", along with their scores.
+Results can be returned alongside additional metadata, including result scores. To return this metadata, set the `results_verbosity` parameter to "verbose" (all metadata), "minimal" (scores only), or "compact" (default, no metadata). If set to "verbose" or "minimal", results will be returned as a list of dictionaries. 
+
+For example, here we get all experimental models associated with "hemoglobin", along with their scores.
+
 ```python
 from rcsbsearchapi.search import TextQuery
 

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -1,20 +1,18 @@
 # Queries
 
 ## Constructing and Executing Queries
-Two syntaxes are available for constructing queries: an "operator" API using python's
-comparators, and a "fluent" API where terms are chained together. Which to use is a
+Two syntaxes are available for constructing queries: an "operator" syntax using Python's
+comparators, and a "fluent" syntax where terms are chained together. Which to use is a
 matter of preference, and both construct the same query object.
 
 ### Operator syntax
-
 Searches are built up from a series of `Terminal` nodes, which compare structural
-attributes to some search value. In the operator syntax, python's comparator
+attributes to some search value. In the operator syntax, Python's comparator
 operators are used to construct the comparison. The operators are overloaded to
 return `Terminal` objects for the comparisons.
 
-Here is an example from the [RCSB PDB Search API](http://search.rcsb.org/#search-example-1) page, using the operator syntax. 
-This query finds symmetric dimers having a twofold rotation with the DNA-binding
-domain of a heat-shock transcription factor.
+Here is an example from the [RCSB PDB Search API](http://search.rcsb.org/#search-example-1) page created using the operator syntax. 
+This query finds symmetric dimers having a twofold rotation with the DNA-binding domain of a heat-shock transcription factor.
 ```python
 from rcsbsearchapi.search import TextQuery
 from rcsbsearchapi import rcsb_attributes as attrs
@@ -26,13 +24,12 @@ q3 = attrs.rcsb_struct_symmetry.kind == "Global Symmetry"
 q4 = attrs.rcsb_entry_info.polymer_entity_count_DNA >= 1
 ```
 Attributes are available from the rcsb_attributes object and can be tab-completed. 
-They can additionally be constructed from strings using the `Attr(attribute)`
-constructor. 
+They can additionally be constructed from strings using the `Attr(attribute)` constructor. 
 
 For methods to search and find details on attributes within this package, go to the [attributes page](attributes.md)
 For a full list of attributes, please refer to the [RCSB PDB schema](http://search.rcsb.org/rcsbsearch/v2/metadata/schema).
 
-`Terminal`s are combined into `Group`s using python's bitwise operators. This is
+Individual `Terminal`s are combined into `Group`s using python's bitwise operators. This is
 analogous to how bitwise operators act on python `set` objects. The operators are
 lazy and won't perform the search until the query is executed.
 
@@ -61,11 +58,11 @@ for options):
 ```python
 results = query(return_type="assembly")  # set return_type to "assembly"
 
-for assemblyid in results:
-    print(assemblyid)
+for assembly_id in results:
+    print(assembly_id)
 ```
-### Fluent syntax
 
+### Fluent syntax
 The operator syntax is great for simple queries, but requires parentheses or
 temporary variables for complex nested queries. In these cases the fluent syntax may
 be clearer. Queries are built up by appending operations sequentially.
@@ -85,39 +82,48 @@ results = TextQuery("heat-shock transcription factor").and_(
     .and_(Attr(attribute="rcsb_struct_symmetry.kind", type="text")).exact_match("Global Symmetry") \
 
     # Add attribute node by name (converted to Attr) with chained operations
-    .and_("rcsb_entry_info.polymer_entity_count_DNA").greater_or_equal(1)
+    .and_("rcsb_entry_info.polymer_entity_count_DNA").greater_or_equal(1) \
+
+    # Execute the query and return assembly ids
     ).exec(return_type="assembly")
 
 # Exec produces an iterator of IDs
-for assemblyid in results:
-    print(assemblyid)
+for assembly_id in results:
+    print(assembly_id)
 ```
 
 ### Structural Attribute Search and Chemical Attribute Search Combination
+Grouping of Structural Attribute and Chemical Attribute queries is permitted. As Structure Attributes and Chemical Attributes are almost all unique, the package is able to determine the search service required. For attributes that are both Structure and Chemical Attributes (`rcsb_id`), specifying a search service is required.
 
-Grouping of a Structural Attribute query and Chemical Attribute query is permitted. As Structure Attributes and Chemical Attributes are almost all unique, the package is able to determine the search service required. For attributes that are both Structure and Chemical Attributes (`rcsb_id`), specifying a search service is required. More details on attributes that are available for text searches can be found on the [RCSB PDB Search API](https://search.rcsb.org/#search-attributes) page.
+More details on attributes that are available for text searches can be found on the [RCSB PDB Search API](https://search.rcsb.org/#search-attributes) page.
 
 ```python
 from rcsbsearchapi.search import AttributeQuery
 
+# Query for structures determined by electron microscopy
 q1 = AttributeQuery(
     attribute="exptl.method",
     operator="exact_match",
     value="electron microscopy"
 )
+
+# Drugbank annotations contain phrase "tylenol"
 q2 = AttributeQuery(
     attribute="drugbank_info.brand_names",
     operator="contains_phrase",
     value="tylenol"
 )
 
-query = q1 & q2 # combining queries
+# Combine queries with AND
+query = q1 & q2
 
 list(query())
 ```
 
 ```python
-# "rcsb_id" is a Structure Attribute and Chemical Attribute, so search service must be specified
+# "rcsb_id" is a Structure Attribute and Chemical Attribute
+# So, search service must be specified
+
 q1 = AttributeQuery(
     attribute="rcsb_id",
     operator="exact_match",
@@ -136,7 +142,6 @@ list(q2())
 ```
 
 ### Computed Structure Models
-
 The [RCSB PDB Search API](https://search.rcsb.org/#results_content_type) page provides information on how to include Computed Structure Models (CSMs) into a search query. Here is a code example below. This query returns IDs for experimental and computed structure models associated with "hemoglobin". Queries for *only* computed models or *only* experimental models can also be made (default).
 ```python
 from rcsbsearchapi.search import TextQuery
@@ -148,8 +153,8 @@ q2 = q1(return_content_type=["computational", "experimental"])
 
 list(q2)
 ```
-### Return Types and Attribute Search
 
+### Return Types and Attribute Search
 A search query can return different result types when a return type is specified. 
 Below are examples on specifying return types Polymer Entities,
 Non-polymer Entities, Polymer Instances, and Molecular Definitions, using a Structure Attribute query. 
@@ -182,7 +187,6 @@ for mol in q1(return_type="mol_definition"):
     print(mol)
 ```
 ## Counting Results
-
 If only the number of results is desired, the count function can be used. This query returns the number of experimental models associated with "hemoglobin".
 ```python
 from rcsbsearchapi.search import TextQuery
@@ -194,7 +198,6 @@ q1.count()
 ```
 
 ## Result Verbosity
-
 Results can be returned alongside additional metadata, including result scores. To return this metadata, set the `results_verbosity` parameter to "verbose" (all metadata), "minimal" (scores only), or "compact" (default, no metadata). If set to "verbose" or "minimal", results will be returned as a list of dictionaries. For example, here we get all experimental models associated with "hemoglobin", along with their scores.
 ```python
 from rcsbsearchapi.search import TextQuery
@@ -205,7 +208,6 @@ for idscore in list(q1(results_verbosity="minimal")):
 ```
 
 ## Sessions
-
 The result of executing a query (either by calling it or using `exec()`) is a
 `Session` object. It implements `__iter__`, so it is usually treated just as an
 iterator of IDs.
@@ -215,8 +217,8 @@ lazily as needed. The page size can be controlled with the `rows` parameter.
 ```python
 first = next(iter(query(rows=1)))
 ```
-### Progress Bar
 
+### Progress Bar
 The `Session.iquery()` method provides a progress bar indicating the number of API
 requests being made. It requires the `tqdm` package be installed to track the
 progress of the query interactively.

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -29,7 +29,8 @@ Attributes are available from the rcsb_attributes object and can be tab-complete
 They can additionally be constructed from strings using the `Attr(attribute)`
 constructor. 
 
-For a full list of attributes, please refer to the [RCSB PDB schema](http://search.rcsb.org/rcsbsearch/v2/metadata/schema). 
+For methods to search and find details on attributes within this package, go to the [attributes page](attributes.md)
+For a full list of attributes, please refer to the [RCSB PDB schema](http://search.rcsb.org/rcsbsearch/v2/metadata/schema).
 
 `Terminal`s are combined into `Group`s using python's bitwise operators. This is
 analogous to how bitwise operators act on python `set` objects. The operators are

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -46,7 +46,11 @@ query = AttributeQuery(
     value="Homo sapiens"
 )
 
+<<<<<<< HEAD
 # Execute query and construct a list from results
+=======
+# Run query and construct a list from results
+>>>>>>> 5a493e6 (documentation edits and adding page for attribute methods)
 results = list(query())
 print(results)
 ```
@@ -61,7 +65,11 @@ from rcsbsearchapi import rcsb_attributes as attrs
 # Search for structures from humans
 query = attrs.rcsb_entity_source_organism.scientific_name == "Homo sapiens"
 
+<<<<<<< HEAD
 # Execute query and construct a list from results
+=======
+# Run query and construct a list from results
+>>>>>>> 5a493e6 (documentation edits and adding page for attribute methods)
 results = list(query())
 print(results)
 ```
@@ -81,14 +89,23 @@ You can combine multiple queries using Python bitwise operators.
 from rcsbsearchapi import rcsb_attributes as attrs
 
 # Query for human epidermal growth factor receptor (EGFR) structures
+<<<<<<< HEAD
 # with investigational or experimental drugs bound.
 # EGFR is involved in cell division and often overexpressed or mutated in cancers
+=======
+# With investigational or experimental drugs bound
+# EGFR is involved in cell division and often overexpressed or mutated in some cancers
+>>>>>>> 5a493e6 (documentation edits and adding page for attribute methods)
 q1 = attrs.rcsb_polymer_entity_container_identifiers.reference_sequence_identifiers.database_accession == "P00533"
 q2 = attrs.rcsb_entity_source_organism.scientific_name == "Homo sapiens"
 q3 = attrs.drugbank_info.drug_groups == "investigational"
 q4 = attrs.drugbank_info.drug_groups == "experimental"
 
+<<<<<<< HEAD
 # Structures matching UniProt id P00533 (EGFR) AND
+=======
+# Structures matching UniProt id P00533 AND
+>>>>>>> 5a493e6 (documentation edits and adding page for attribute methods)
 # from humans AND
 # investigational OR experimental drug group
 query = q1 & q2 & (q3 | q4)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,6 +9,7 @@ Get it from PyPI:
 Or, download from [GitHub](https://github.com/rcsb/py-rcsbsearchapi)
 
 ## Getting Started
+### Making full-text queries
 
 To perform a general search for structures associated with the phrase "Hemoglobin", you can create a TextQuery. This does a "full-text" search, which is a general search on text associated with PDB structures or molecular definitions. Learn more about available search services on the [RCSB PDB Search API docs](https://search.rcsb.org/#search-services).
 ```python
@@ -25,21 +26,23 @@ for id in results:
     print(id)
 ```
 
+### Making attribute queries
+
 Besides general text searches, you can also search for specific structure or chemical attributes. 
 
+To search an attribute, you can make an `AttributeQuery`.
 Using different operators such as `contains_phrase` or `exact_match`, attributes can be compared to a value.
 You can also check whether an attribute exists for a given structure by using the `exists` operator. 
 
 Refer to the [Search Attributes](https://search.rcsb.org/structure-search-attributes.html) and [Chemical Attributes](https://search.rcsb.org/chemical-search-attributes.html) documentation for a full list of attributes and applicable operators.
 
-To search an attribute, you can make an AttributeQuery.
 ```python
 from rcsbsearchapi import AttributeQuery
 
 # Construct the query
 query = AttributeQuery(
     attribute="rcsb_entity_source_organism.scientific_name",
-    operator="exact_match",  # other operators include "contains phrase" and "exists"
+    operator="exact_match",  # other operators include "contains_phrase" and "exists"
     value="Homo sapiens"
 )
 results = list(query())  # construct a list from query results
@@ -58,6 +61,7 @@ query = attrs.rcsb_entity_source_organism.scientific_name == "Homo sapiens"
 results = list(query())  # construct a list from query results
 print(results)
 ```
+### Combining queries using operators
 
 You can combine multiple queries using Python bitwise operators. 
 
@@ -66,8 +70,8 @@ You can combine multiple queries using Python bitwise operators.
 |&       |AND                     |
 |\|      |OR                      |
 |~       |NOT                     |
+|^       |XOR/symmetric difference|
 |-       |set difference          |
-|^       |symmetric difference/XOR|
 
 ```python
 from rcsbsearchapi import rcsb_attributes as attrs

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -39,13 +39,15 @@ Refer to the [Search Attributes](https://search.rcsb.org/structure-search-attrib
 ```python
 from rcsbsearchapi import AttributeQuery
 
-# Construct the query
+# Construct a query searching for structures from humans
 query = AttributeQuery(
     attribute="rcsb_entity_source_organism.scientific_name",
-    operator="exact_match",  # other operators include "contains_phrase" and "exists"
+    operator="exact_match",  # Other operators include "contains_phrase" and "exists"
     value="Homo sapiens"
 )
-results = list(query())  # construct a list from query results
+
+# Run query and construct a list from results
+results = list(query())
 print(results)
 ```
 
@@ -58,7 +60,9 @@ from rcsbsearchapi import rcsb_attributes as attrs
 
 # Search for structures from humans
 query = attrs.rcsb_entity_source_organism.scientific_name == "Homo sapiens"
-results = list(query())  # construct a list from query results
+
+# Run query and construct a list from results
+results = list(query())
 print(results)
 ```
 ### Combining queries using operators
@@ -76,14 +80,17 @@ You can combine multiple queries using Python bitwise operators.
 ```python
 from rcsbsearchapi import rcsb_attributes as attrs
 
-# Query for human epidermal growth factor receptor (EGFR) structures with investigational or experimental drugs
+# Query for human epidermal growth factor receptor (EGFR) structures
+# With investigational or experimental drugs bound
 # EGFR is involved in cell division and often overexpressed or mutated in some cancers
 q1 = attrs.rcsb_polymer_entity_container_identifiers.reference_sequence_identifiers.database_accession == "P00533"
 q2 = attrs.rcsb_entity_source_organism.scientific_name == "Homo sapiens"
 q3 = attrs.drugbank_info.drug_groups == "investigational"
 q4 = attrs.drugbank_info.drug_groups == "experimental"
 
-# Structures matching UniProt id P00533 AND from humans AND (investigational or experimental drug group)
+# Structures matching UniProt id P00533 AND
+# from humans AND
+# investigational OR experimental drug group
 query = q1 & q2 & (q3 | q4)
 
 # Execute query and print first 10 ids

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -46,7 +46,7 @@ query = AttributeQuery(
     value="Homo sapiens"
 )
 
-# Run query and construct a list from results
+# Execute query and construct a list from results
 results = list(query())
 print(results)
 ```
@@ -61,7 +61,7 @@ from rcsbsearchapi import rcsb_attributes as attrs
 # Search for structures from humans
 query = attrs.rcsb_entity_source_organism.scientific_name == "Homo sapiens"
 
-# Run query and construct a list from results
+# Execute query and construct a list from results
 results = list(query())
 print(results)
 ```
@@ -81,14 +81,14 @@ You can combine multiple queries using Python bitwise operators.
 from rcsbsearchapi import rcsb_attributes as attrs
 
 # Query for human epidermal growth factor receptor (EGFR) structures
-# With investigational or experimental drugs bound
-# EGFR is involved in cell division and often overexpressed or mutated in some cancers
+# with investigational or experimental drugs bound.
+# EGFR is involved in cell division and often overexpressed or mutated in cancers
 q1 = attrs.rcsb_polymer_entity_container_identifiers.reference_sequence_identifiers.database_accession == "P00533"
 q2 = attrs.rcsb_entity_source_organism.scientific_name == "Homo sapiens"
 q3 = attrs.drugbank_info.drug_groups == "investigational"
 q4 = attrs.drugbank_info.drug_groups == "experimental"
 
-# Structures matching UniProt id P00533 AND
+# Structures matching UniProt id P00533 (EGFR) AND
 # from humans AND
 # investigational OR experimental drug group
 query = q1 & q2 & (q3 | q4)
@@ -98,11 +98,11 @@ results = list(query())
 print(results[:10])
 ```
 
-These examples are in `operator syntax`. You can also make queries in `fluent syntax`. Learn more about both syntaxes and implementation details in [Queries](queries.md#constructing-and-executing-queries).
+These examples are in `operator syntax`. You can also make queries in `fluent syntax`. Learn more about both syntaxes and implementation details in [readthedocs: Queries](queries.md#constructing-and-executing-queries).
 
 ## Jupyter Notebooks
-A runnable jupyter notebook with this example is available in [notebooks/quickstart.ipynb](notebooks/quickstart.ipynb), or can be run online using Google Colab:
+A runnable jupyter notebook is available in [notebooks/quickstart.ipynb](https://github.com/rcsb/py-rcsbsearchapi/blob/master/notebooks/quickstart.ipynb), or can be run online using Google Colab:
 <a href="https://colab.research.google.com/github/rcsb/py-rcsbsearchapi/blob/master/notebooks/quickstart.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
 
-An additional example including a Covid-19 related example is in [notebooks/covid.ipynb](notebooks/covid.ipynb):
+An additional Covid-19 related example is in [notebooks/covid.ipynb](https://github.com/rcsb/py-rcsbsearchapi/blob/master/notebooks/covid.ipynb):
 <a href="https://colab.research.google.com/github//rcsb/py-rcsbsearchapi/blob/master/notebooks/covid.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,528 +8,90 @@ Get it from PyPI:
 
 Or, download from [GitHub](https://github.com/rcsb/py-rcsbsearchapi)
 
-## Syntax
+## Getting Started
 
-Here is a quick example of how the package is used. Two syntaxes are available for
-constructing queries: an "operator" API using python's comparators, and a "fluent"
-syntax where terms are chained together. Which to use is a matter of preference.
-
-A runnable jupyter notebook with this example is available in [notebooks/quickstart.ipynb](notebooks/quickstart.ipynb), or can be run online using binder:
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/rcsb/py-rcsbsearchapi/master?labpath=notebooks%2Fquickstart.ipynb)
-
-An additional example including a Covid-19 related example is in [notebooks/covid.ipynb](notebooks/covid.ipynb):
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/rcsb/py-rcsbsearchapi/master?labpath=notebooks%2Fcovid.ipynb)
-
-### Operator Example
-
-Here is an example from the [RCSB PDB Search API](http://search.rcsb.org/#search-example-1) page, using the operator syntax. 
-This query finds symmetric dimers having a twofold rotation with the DNA-binding
-domain of a heat-shock transcription factor.
+To perform a general search for structures associated with the phrase "Hemoglobin", you can create a TextQuery. This does a "full-text" search, which is a general search on text associated with PDB structures or molecular definitions. Learn more about available search services on the [RCSB PDB Search API docs](https://search.rcsb.org/#search-services).
 ```python
-from rcsbsearchapi.search import TextQuery
-from rcsbsearchapi import rcsb_attributes as attrs
+from rcsbsearchapi import TextQuery
 
-# Create terminals for each query
-q1 = TextQuery("heat-shock transcription factor")
-q2 = attrs.rcsb_struct_symmetry.symbol == "C2"
-q3 = attrs.rcsb_struct_symmetry.kind == "Global Symmetry"
-q4 = attrs.rcsb_entry_info.polymer_entity_count_DNA >= 1
+# Search for structures associated with the phrase "Hemoglobin"
+query = TextQuery(value="Hemoglobin")
 
-# combined using bitwise operators (&, |, ~, etc)
-query = q1 & (q2 & q3 & q4)
+# Execute the query by running it as a function
+results = query()
 
-# Call the query to execute it
-for assemblyid in query("assembly"):
-    print(assemblyid)
-```
-For a full list of attributes, please refer to the [RCSB PDB schema](http://search.rcsb.org/rcsbsearch/v2/metadata/schema).
-
-### Fluent Example
-
-Here is the same example using the fluent syntax
-```python
-from rcsbsearchapi.search import TextQuery, AttributeQuery, Attr
-
-# Start with a Attr or TextQuery, then add terms
-results = TextQuery("heat-shock transcription factor").and_(
-    # Add attribute node as fully-formed AttributeQuery
-    AttributeQuery(attribute="rcsb_struct_symmetry.symbol", operator="exact_match", value="C2") \
-    # Add attribute node as Attr with chained operations
-    .and_(Attr("rcsb_struct_symmetry.kind")).exact_match("Global Symmetry") \
-    # Add attribute node by name (converted to Attr) with chained operations
-    .and_("rcsb_entry_info.polymer_entity_count_DNA").greater_or_equal(1)
-    ).exec("assembly")
-
-# Exec produces an iterator of IDs
-for assemblyid in results:
-    print(assemblyid)
-```
-### Structural Attribute Search and Chemical Attribute Search Combination
-
-Grouping of a Structural Attribute query and Chemical Attribute query is permitted as long as grouping is done correctly and search services are specified accordingly. More details on attributes that are available for text searches can be found on the [RCSB PDB Search API](https://search.rcsb.org/#search-attributes) page.
-```python
-from rcsbsearchapi.const import CHEMICAL_ATTRIBUTE_SEARCH_SERVICE, STRUCTURE_ATTRIBUTE_SEARCH_SERVICE
-from rcsbsearchapi.search import AttributeQuery
-
-# By default, service is set to "text" for structural attribute search
-q1 = AttributeQuery("exptl.method", "exact_match", "electron microscopy",
-                    STRUCTURE_ATTRIBUTE_SEARCH_SERVICE # this constant specifies "text" service
-                    )
-
-# Need to specify chemical attribute search service - "text_chem"
-q2 = AttributeQuery("drugbank_info.brand_names", "contains_phrase", "tylenol",
-                    CHEMICAL_ATTRIBUTE_SEARCH_SERVICE # this constant specifies "text_chem" service
-                    )
-
-query = q1 & q2 # combining queries
-
-list(query())
-```
-### Computed Structure Models
-
-The [RCSB PDB Search API](https://search.rcsb.org/#results_content_type) page provides information on how to include Computed Structure Models (CSMs) into a search query. Here is a code example below. This query returns IDs for experimental and computed structure models associated with "hemoglobin". Queries for *only* computed models or *only* experimental models can also be made (default).
-```python
-from rcsbsearchapi.search import TextQuery
-    
-q1 = TextQuery("hemoglobin")
-
-# add parameter as a list with either "computational" or "experimental" or both as list values
-q2 = q1(return_content_type=["computational", "experimental"])
-
-list(q2)
-```
-### Return Types and Attribute Search
-
-A search query can return different result types when a return type is specified. 
-Below are examples on specifying return types Polymer Entities,
-Non-polymer Entities, Polymer Instances, and Molecular Definitions, using a Structure Attribute query. 
-More information on return types can be found in the 
-[RCSB PDB Search API](https://search.rcsb.org/#building-search-request) page.
-```python
-from rcsbsearchapi.search import AttributeQuery
-
-q1 = AttributeQuery("rcsb_entry_container_identifiers.entry_id", "in", ["4HHB"]) # query for 4HHB deoxyhemoglobin
-
-# Polymer entities
-for poly in q1("polymer_entity"): # include return type as a string parameter for query object
-    print(poly)
-    
-# Non-polymer entities
-for nonPoly in q1("non_polymer_entity"):
-    print(nonPoly)
-    
-# Polymer instances
-for polyInst in q1("polymer_instance"):
-    print(polyInst)
-    
-# Molecular definitions
-for mol in q1("mol_definition"):
-    print(mol)
-```
-### Counting Results
-
-If only the number of results is desired, the count function can be used. This query returns the number of experimental models associated with "hemoglobin".
-```python
-from rcsbsearchapi.search import TextQuery
-
-q1 = TextQuery("hemoglobin")
-
-# N.B., Just as shown above for `query()`, `return_type` and `return_content_type` can also be specified as parameters to `count()`
-q1.count()
-```
-### Obtaining Scores for Results
-
-Results can be returned alongside additional metadata, including result scores. To return this metadata, set the `results_verbosity` parameter to "verbose" (all metadata), "minimal" (scores only), or "compact" (default, no metadata). If set to "verbose" or "minimal", results will be returned as a list of dictionaries. For example, here we get all experimental models associated with "hemoglobin", along with their scores.
-```python
-from rcsbsearchapi.search import TextQuery
-
-q1 = TextQuery("hemoglobin")
-for idscore in list(q1(results_verbosity="minimal")):
-    print(idscore)
-```
-### Protein Sequence Search Example
-
-Below is an example from the [RCSB PDB Search API](https://search.rcsb.org/#search-example-3) page, 
-using the sequence search function.
-This query finds macromolecular PDB entities that share 90% sequence identity with
-GTPase HRas protein from *Gallus gallus* (*Chicken*).
-```python
-from rcsbsearchapi.search import SequenceQuery
-
-# Use SequenceQuery class and add parameters
-results = SequenceQuery("MTEYKLVVVGAGGVGKSALTIQLIQNHFVDEYDPTIEDSYRKQVVIDGET" +
-                        "CLLDILDTAGQEEYSAMRDQYMRTGEGFLCVFAINNTKSFEDIHQYREQI" +
-                        "KRVKDSDDVPMVLVGNKCDLPARTVETRQAQDLARSYGIPYIETSAKTRQ" +
-                        "GVEDAFYTLVREIRQHKLRKLNPPDESGPGCMNCKCVIS", 1, 0.9)
-    
-# results("polymer_entity") produces an iterator of IDs with return type - polymer entities
-for polyid in results("polymer_entity"):
-    print(polyid)
-```
-### Sequence Motif Search Example
-
-Below is an example from the [RCSB PDB Search API](https://search.rcsb.org/#search-example-6) page,
-using the sequence motif search function. 
-This query retrives occurences of the His2/Cys2 Zinc Finger DNA-binding domain as
-represented by its PROSITE signature. 
-```python
-from rcsbsearchapi.search import SeqMotifQuery
-
-# Use SeqMotifQuery class and add parameters
-results = SeqMotifQuery("C-x(2,4)-C-x(3)-[LIVMFYWC]-x(8)-H-x(3,5)-H.",
-                        pattern_type="prosite",
-                        sequence_type="protein")
-
-# results("polymer_entity") produces an iterator of IDs with return type - polymer entities
-for polyid in results("polymer_entity"):
-    print(polyid)
-```
-
-You can also use a regular expression (RegEx) to make a sequence motif search.
-As an example, here is a query for the zinc finger motif that binds Zn in a DNA-binding domain:
-```python
-from rcsbsearchapi.search import SeqMotifQuery
-
-results = SeqMotifQuery("C.{2,4}C.{12}H.{3,5}H", pattern_type="regex", sequence_type="protein")
-
-for polyid in results("polymer_entity"):
-    print(polyid)
-```
-
-You can use a standard amino acid sequence to make a sequence motif search. 
-X can be used to allow any amino acid in that position. 
-As an example, here is a query for SH3 domains:
-```python
-from rcsbsearchapi.search import SeqMotifQuery
-
-# By default, the pattern_type argument is "simple" and the sequence_type argument is "protein".
-results = SeqMotifQuery("XPPXP")  # X is used as a "variable residue" and can be any amino acid. 
-
-for polyid in results("polymer_entity"):
-    print(polyid)
-```
-
-All 3 of these pattern types can be used to search for DNA and RNA sequences as well.
-Demonstrated are 2 queries, one DNA and one RNA, using the simple pattern type:
-```python
-from rcsbsearchapi.search import SeqMotifQuery
-
-# DNA query: this is a query for a T-Box.
-dna = SeqMotifQuery("TCACACCT", sequence_type="dna")
-
-print("DNA results:")
-for polyid in dna("polymer_entity"):
-    print(polyid)
-
-# RNA query: 6C RNA motif
-rna = SeqMotifQuery("CCCCCC", sequence_type="rna")
-print("RNA results:")
-for polyid in rna("polymer_entity"):
-    print(polyid)
-```
-### Structure Similarity Query Example
-
-The PDB archive can be queried using the 3D shape of a protein structure. To perform this query, 3D protein structure data must be provided as an input or parameter, A chain ID or assembly ID must be specified, whether the input structure data should be compared to Assemblies or Polymer Entity Instance (Chains) is required, and defining the search type as either strict or relaxed is required. More information on how Structure Similarity Queries work can be found on the [RCSB PDB Structure Similarity Search](https://www.rcsb.org/docs/search-and-browse/advanced-search/structure-similarity-search) page.
-```python
-from rcsbsearchapi.search import StructSimilarityQuery
-
-# Basic query: querying using entry ID and default values assembly ID "1", operator "strict", and target search space "Assemblies"
-q1 = StructSimilarityQuery(entry_id="4HHB")
-
-# Same example but with parameters explicitly specified
-q1 = StructSimilarityQuery(structure_search_type="entry_id",
-                           entry_id="4HHB",
-                           structure_input_type="assembly_id",
-                           assembly_id="1",
-                           operator="strict_shape_match",
-                           target_search_space="assembly"
-                           )
-for id in q1("assembly"):
+# Results are returned as an iterator of result identifiers.
+for id in results:
     print(id)
 ```
-Below is a more complex example that utilizes chain ID, relaxed search operator, and polymer entity instance or target search space. Specifying whether the input structure
-type is chain id or assembly id is very important. For example, specifying chain ID as the input structure type but inputting an assembly ID can lead to
-an error.
+
+Besides general text searches, you can also search for specific structure or chemical attributes. 
+
+Using different operators such as `contains_phrase` or `exact_match`, attributes can be compared to a value.
+You can also check whether an attribute exists for a given structure by using the `exists` operator. 
+
+Refer to the [Search Attributes](https://search.rcsb.org/structure-search-attributes.html) and [Chemical Attributes](https://search.rcsb.org/chemical-search-attributes.html) documentation for a full list of attributes and applicable operators.
+
+To search an attribute, you can make an AttributeQuery.
 ```python
-from rcsbsearchapi.search import StructSimilarityQuery
+from rcsbsearchapi import AttributeQuery
 
-# More complex query with entry ID value "4HHB", chain ID "B", operator "relaxed", and target search space "Chains"
-q2 = StructSimilarityQuery(structure_search_type="entry_id",
-                                   entry_id="4HHB",
-                                   structure_input_type="chain_id",
-                                   chain_id="B",
-                                   operator="relaxed_shape_match",
-                                   target_search_space="polymer_entity_instance")
-list(q2())
-```
-Structure similarity queries also allow users to upload a file from their local computer or input a file url from the website to query the PDB archive for similar proteins. The file represents a target protein structure in the file formats "cif", "bcif", "pdb", "cif.gz", or "pdb.gz". If a user wants to use a file url for queries, the user must specify the structure search type, the value (being the url), and the file format of the file. This is also the same case for file upload, except the value is the absolute path leading to the file that is in the local machine. An example for file url is below for 4HHB (hemoglobin).
-```python
-from rcsbsearchapi.search import StructSimilarityQuery
-
-q3 = StructSimilarityQuery(structure_search_type="file_url",
-                           file_url="https://files.rcsb.org/view/4HHB.cif",
-                           file_format="cif")
-list(q3())
-
-# If you want to upload your own structure file for similarity search, you can do so by using the `file_path` parameter:
-q4 = StructSimilarityQuery(structure_search_type="file_upload",
-                           file_path="/PATH/TO/FILE.cif",  # specify local model file path
-                           file_format="cif")
-list(q4())
+# Construct the query
+query = AttributeQuery(
+    attribute="rcsb_entity_source_organism.scientific_name",
+    operator="exact_match",  # other operators include "contains phrase" and "exists"
+    value="Homo sapiens"
+)
+results = list(query())  # construct a list from query results
+print(results)
 ```
 
-### Structure Motif Query Examples
+When using certain operators such as `exact_match`, `greater`, or `less`, you can also use `rcsb_attributes` (imported below as `attrs`).
 
-The PDB Archive can also be queried by using a "motif" found in these 3D structures. To perform this type of query, an entry_id or a file URL/path must be provided, along with residues (which are parts of 3D structures.) This is the bare minimum needed to make a search, but there are lots of other parameters that can be added to a Structure Motif Query (see [full search schema](https://search.rcsb.org/redoc/index.html)).
+Using this syntax, attribute names can be tab-completed. 
 
-To make a Structure Motif Query, you must first define anywhere from 2-10 "residues" that will be used in the query. Each individual residue has a Chain ID, Operator, Residue Number, and Exchanges (optional) that can be declared in that order using positonal arguments, or using the "chain_id", "struct_oper_id", and "label_seq_id" to define what parameter you are passing through. All 3 of the required parameters must be included, or the package will throw an AssertionError. 
-
-Each residue can only have a maximum of 4 Exchanges, and each query can only have 16 exchanges total. Violating any of these rules will cause the package to throw an AssertionError. 
-
-Examples of how to instantiate Residues can be found below. These can then be put into a list and passed through to a Structure Motif Query.
 ```python
-from rcsbsearchapi.search import StructureMotifResidue
+from rcsbsearchapi import rcsb_attributes as attrs
 
-# construct a Residue with a Chain ID of A, an operator of 1, a residue 
-# number of 192, and Exchanges of "LYS" and "HIS"
-Res1 = StructureMotifResidue("A", "1", 192, ["LYS", "HIS"])
-# as for what is a valid "Exchange", the package provides these as a literal,
-# and they should be type checked. 
-
-# you can also specify the arguments:
-# this query is the same as above. 
-Res2 = StructureMotifResidue(struct_oper_id="1", chain_id="A", exchanges=["LYS", "HIS"], label_seq_id=192)
-
-# after delcaring a minimum of 2 and as many as 10 residues, they can be passed into a list for use in the query itself:
-Res3 = StructureMotifResidue("A", "1", 162)  # exchanges are optional
-
-ResList = [Res1, Res3]
-```
-From there, these Residues can be used in a query. As stated before, you can only include 2 - 10 residues in a query. If you fail to provide residues for a query, or provide the wrong amount, the package will throw a ValueError. 
-
-For a Structure Motif Query using an entry_id, the only other necessary value that must be passed into the query is the residue list. The default type of query is an entry_id query. 
-
-As this type of query has a lot of optional parameters, do *not* use positional arguments as more than likely an error will occur. 
-
-Below is an example of a basic entry_id Structure Motif Query, with the residues declared earlier:
-```python
-from rcsbsearchapi.search import StructMotifQuery
-
-q1 = StructMotifQuery(entry_id="2MNR", residue_ids=ResList)
-list(q1())
-```
-Like with Structure Similarity Queries, a file url or filepath can also be provided to the program. These can take the place of an entry_id. 
-
-For a file url query, you *must* provide both a valid file URL (a string), and the file's file extension (also as a string). Failure to provide these elements correctly will cause the package to throw an AssertionError. 
-
-Below is an example of the same query as above, only this time providing a file url:
-```python
-link = "https://files.rcsb.org/view/2MNR.cif"
-q2 = StructMotifQuery(structure_search_type="file_url", url=link, file_extension="cif", residue_ids=ResList)
-# structure_search_type MUST be provided. A mismatched query type will cause an error. 
-list(q2())
-```
-Like with Structure Similarity Queries, a filepath to a file may also be provided. This file must be a valid file accepted by the search API. A file extension must also be provided with the file upload. 
-
-The query would look something like this:
-```python
-filepath = "/absolute/path/to/file.cif"
-q3 = StructMotifQuery(structure_search_type="file_upload", file_path=filepath, file_extension="cif", residue_ids=ResList)
-
-list(q3())
-```
-There are many additional parameters that Structure Motif Query supports. These include a variety of features such as backbone distance tolerance, side chain distance tolerance, angle tolerance, RMSD cutoff, limits (stop searching after this many hits), atom pairing schemes, motif pruning strategy, allowed structures, and excluded structures. These can be mixed and matched as needed to make accurate and useful queries. All of these have some default value which is used when a parameter isn't provided. These parameters conform to the defaults used by the Search API. 
-
-Below will demonstrate how to define these parameters using non-positional arguments:
-```python
-# specifying backbone distance tolerance: 0-3, default is 1
-# allowed backbone distance tolerance in Angstrom. 
-backbone = StructMotifQuery(entry_id="2MNR", backbone_distance_tolerance=2, residue_ids=ResList)
-list(backbone())
-
-# specifying sidechain distance tolerance: 0-3, default is 1
-# allowed side-chain distance tolerance in Angstrom.
-sidechain = StructMotifQuery(entry_id="2MNR", side_chain_distance_tolerance=2, residue_ids=ResList)
-list(sidechain())
-
-# specifying angle tolerance: 0-3, default is 1
-# allowed angle tolerance in multiples of 20 degrees. 
-angle = StructMotifQuery(entry_id="2MNR", angle_tolerance=2, residue_ids=ResList)
-list(angle())
-
-# specifying RMSD cutoff: >=0, default is 2
-# Threshold above which hits will be filtered by RMSD
-rmsd = StructMotifQuery(entry_id="2MNR", rmsd_cutoff=1, residue_ids=ResList)
-list(rmsd())
-
-# specifying limit: >=0, default excluded
-# Stop accepting results after this many hits. 
-limit = StructMotifQuery(entry_id="2MNR", limit=100, residue_ids=ResList)
-list(limit())
-
-# specifying atom pairing scheme, default = "SIDE_CHAIN"
-# ENUM: "ALL", "BACKBONE", "SIDE_CHAIN", "PSUEDO_ATOMS"
-# this is typechecked by a literal. 
-# Which atoms to consider to compute RMSD scores and transformations. 
-atom = StructMotifQuery(entry_id="2MNR", atom_pairing_scheme="ALL", residue_ids=ResList)
-list(atom())
-
-# specifying motif pruning strategy, default = "KRUSKAL"
-# ENUM: "NONE", "KRUSKAL"
-# this is typechecked by a literal in the package. 
-# Specifies how many query motifs are "pruned". KRUSKAL leads to less stringent queries, and faster results.
-pruning = StructMotifQuery(entry_id="2MNR", motif_pruning_strategy="NONE", residue_ids=ResList)
-list(pruning())
-
-# specifying allowed structures, default excluded
-# specify the structures you wish to allow in the return result. As an example,
-# we could only allow the results from the limited query we ran earlier. 
-allowed = StructMotifQuery(entry_id="2MNR", allowed_structures=list(limit()), residue_ids=ResList)
-list(allowed())
-
-# specifying structures to exclude, default excluded
-# specify structures to exclude from a query. We could, for example,
-# exclude the results of the previous allowed query. 
-excluded = StructMotifQuery(entry_id="2MNR", excluded_structures=list(allowed()), residue_ids=ResList)
-list(excluded())
-```
-The Structure Motif Query can be used to make some very specific queries. Below is an example of a query that retrives occurances of the enolase superfamily, a group of proteins diverse in sequence and structure that are all capable of abstracting a proton from a carboxylic acid. Position-specific exchanges are crucial to represent this superfamily accurately.
-```python
-Res1 = StructureMotifResidue("A", "1", 162, ["LYS", "HIS"])
-Res2 = StructureMotifResidue("A", "1", 193)
-Res3 = StructureMotifResidue("A", "1", 219)
-Res4 = StructureMotifResidue("A", "1", 245, ["GLU", "ASP", "ASN"])
-Res5 = StructureMotifResidue("A", "1", 295, ["HIS", "LYS"])
-
-ResList = [Res1, Res2, Res3, Res4, Res5]
-
-query = StructMotifQuery(entry_id="2MNR", residue_ids=ResList)
-
-list(query())
-```
-### Chemical Similarity Query
-
-When you have unique chemical information (e.g., a chemical formula or descriptor) you can use this information to find chemical components (e.g., drugs, inhibitors, modified residues, or building blocks such as amino acids, nucleotides, or sugars), so that it is similar to the formula or descriptor used in the query (perhaps one or two atoms/groups are different), is part of a larger molecule (i.e., the specified formula/descriptor is a substructure), or is exactly or very closely matches the formula or descriptor used in the query. 
-
-The search can also be used to identify PDB structures that include the chemical component(s) which match or are similar to the query. These structures can then be examined to learn about the interactions of the component within the structure. More information on Chemical Similarity Queries can be found on the [RCSB PDB Chemical Similarity Search](https://www.rcsb.org/docs/search-and-browse/advanced-search/chemical-similarity-search) page.
-
-To do a Chemical Similarity query, you must first specify one of two possible query options which are formula and descriptors. Formula allows queries to be made by providing a chemical formula. Descriptors allow you to search by chemical notations for example. Each Query option has its own distinct set of parameters, but both options require a value.
-
-The formula query option comes with a match subset parameter which allows users to search chemical components whose formula exactly match the query or matches any portion of the query. The descriptor query option comes with a descriptor type parameter and match type parameter. The descriptor type parameter specifies what type of descriptor the input value is. There are two options which are SMILES (Simplified Molecular Input Line Entry Specification) and InChI (International Chemical Identifier). The match type parameter has six options which are Similar Ligands (Quick Screen), Similar Ligands (Stereospecific), Similar Ligands (including Stereoisomers), Substructure (Stereospecific), Substructure (including Stereoisomers), and Exact match.
-
-When doing Chemical Similarity Queries in this tool, it is important to note that by default the query option is set to formula and match subset is set to False. An example of how that looks like is below.
-```python
-from rcsbsearchapi.search import ChemSimilarityQuery
-
-# Basic query with default values: query type = formula and match subset = False
-q1 = ChemSimilarityQuery(value="C12 H17 N4 O S")
-
-# Same example but with all the parameters listed
-q1 = ChemSimilarityQuery(value="C12 H17 N4 O S",
-                         query_type="formula",
-                         match_subset=False)
-list(q1())
-```
-Below is are two examples of using query option descriptor. Both descriptor type parameters are also used.
-```python
-from rcsbsearchapi.search import ChemSimilarityQuery
-
-# Query with type = descriptor, descriptor type = SMILES, match type = similar ligands (sterospecific) or graph-relaxed-stereo
-q2 = ChemSimilarityQuery(value="Cc1c(sc[n+]1Cc2cnc(nc2N)C)CCO",
-                         query_type="descriptor",
-                         descriptor_type="SMILES",
-                         match_type="graph-relaxed-stereo")
-list(q2())
-```
-```python
-from rcsbsearchapi.search import ChemSimilarityQuery
-
-# Query with type = descriptor, descriptor type = InChI, match type = substructure (sterospecific) or sub-struct-graph-relaxed-stereo
-q3 = ChemSimilarityQuery(value="InChI=1S/C13H10N2O4/c16-10-6-5-9(11(17)14-10)15-12(18)7-3-1-2-4-8(7)13(15)19/h1-4,9H,5-6H2,(H,14,16,17)/t9-/m0/s1",
-                         query_type="descriptor",
-                         descriptor_type="InChI",
-                         match_type="sub-struct-graph-relaxed-stereo")
-list(q3())
-```
-### Faceted Query Examples
-In order to group and perform calculations and statistics on PDB data by using a simple search query, you can use a faceted query (or facets). Facets arrange search results into categories (buckets) based on the requested field values. More information on Faceted Queries can be found [here](https://search.rcsb.org/#using-facets). All facets should be provided with `name`, `aggregation_type`, and `attribute` values. Depending on the aggregation type, other parameters must also be specified. The `facets()` function runs the query `q` using the specified facet(s), and returns a list of dictionaries:
-```python
-from rcsbsearchapi.search import AttributeQuery, Facet, Range
-
-q = AttributeQuery("rcsb_accession_info.initial_release_date", operator="greater", value="2019-08-20")
-q.facets(facets=Facet(name="Methods", aggregation_type="terms", attribute="exptl.method"))
+# Search for structures from humans
+query = attrs.rcsb_entity_source_organism.scientific_name == "Homo sapiens"
+results = list(query())  # construct a list from query results
+print(results)
 ```
 
-#### Term Facets
-Terms faceting is a multi-bucket aggregation where buckets are dynamically built - one per unique value. We can specify the minimum count (`>= 0`) for a bucket to be returned using the parameter `min_interval_population` (default value `1`). We can also control the number of buckets returned (`<= 65336`) using the parameter `max_num_intervals` (default value `65336`).
-```python
-# This is the default query, used by the RCSB Search API when no query is explicitly specified.
-# This default query will be used for most of the examples found below for faceted queries.
-base_q = AttributeQuery("rcsb_entry_info.structure_determination_methodology", operator="exact_match", value="experimental") 
+You can combine multiple queries using Python bitwise operators. 
 
-base_q.facets(facets=Facet(name="Journals", aggregation_type="terms", attribute="rcsb_primary_citation.rcsb_journal_abbrev", min_interval_population=1000))
+|Operator|Description             |
+|--------|------------------------|
+|&       |AND                     |
+|\|      |OR                      |
+|~       |NOT                     |
+|-       |set difference          |
+|^       |symmetric difference/XOR|
+
+```python
+from rcsbsearchapi import rcsb_attributes as attrs
+
+# Query for human epidermal growth factor receptor (EGFR) structures with investigational or experimental drugs
+# EGFR is involved in cell division and often overexpressed or mutated in some cancers
+q1 = attrs.rcsb_polymer_entity_container_identifiers.reference_sequence_identifiers.database_accession == "P00533"
+q2 = attrs.rcsb_entity_source_organism.scientific_name == "Homo sapiens"
+q3 = attrs.drugbank_info.drug_groups == "investigational"
+q4 = attrs.drugbank_info.drug_groups == "experimental"
+
+# Structures matching UniProt id P00533 AND from humans AND (investigational or experimental drug group)
+query = q1 & q2 & (q3 | q4)
+
+# Execute query and print first 10 ids
+results = list(query())
+print(results[:10])
 ```
 
-#### Histogram Facets
-Histogram facets build fixed-sized buckets (intervals) over numeric values. The size of the intervals must be specified in the parameter `interval`. We can also specify `min_interval_population` if desired.
-```python
-base_q.facets(return_type="polymer_entity", facets=Facet(name="Formula Weight", aggregation_type="histogram", attribute="rcsb_polymer_entity.formula_weight", interval=50, min_interval_population=1))
-```
+These examples are in `operator syntax`. You can also make queries in `fluent syntax`. Learn more about both syntaxes and implementation details in [Queries](queries.md#constructing-and-executing-queries).
 
-#### Date Histogram Facets
-Similar to histogram facets, date histogram facetes build buckets over date values. For date histogram aggregations, we must specify `interval="year"`. Again, we may also specify `min_interval_population`.
-```python
-base_q.facets(facets=Facet(name="Release Date", aggregation_type="date_histogram", attribute="rcsb_accession_info.initial_release_date", interval="year", min_interval_population=1))
-```
+## Jupyter Notebooks
+A runnable jupyter notebook with this example is available in [notebooks/quickstart.ipynb](notebooks/quickstart.ipynb), or can be run online using Google Colab:
+<a href="https://colab.research.google.com/github/rcsb/py-rcsbsearchapi/blob/master/notebooks/quickstart.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
 
-#### Range Facets
-We can define the buckets ourselves by using range facets. In order to specify the ranges, we use the `Range` class. Note that the range includes the `start` value and excludes the `end` value (`include_lower` and `include_upper` should not be specified). If the `start` or `end` is omitted, the minimum or maximum boundaries will be used by default. The buckets should be provided as a list of `Range` objects to the `ranges` parameter.  
-```python
-base_q.facets(facets=Facet(name="Resolution Combined", aggregation_type="range", attribute="rcsb_entry_info.resolution_combined", ranges=[Range(start=None,end=2), Range(start=2, end=2.2), Range(start=2.2, end=2.4), Range(start=4.6, end=None)]))
-```
-
-#### Date Range Facets
-Date range facets allow us to specify date values as bucket ranges, using [date math expressions](https://search.rcsb.org/#date-math-expressions).
-```python
-base_q.facets(facets=Facet(name="Release Date", aggregation_type="date_range", attribute="rcsb_accession_info.initial_release_date", ranges=[Range(start=None,end="2020-06-01||-12M"), Range(start="2020-06-01", end="2020-06-01||+12M"), Range(start="2020-06-01||+12M", end=None)]))
-```
-
-#### Cardinality Facets 
-Cardinality facets return a single value: the count of distinct values returned for a given field. A `precision_threshold` (`<= 40000`, default value `40000`) may be specified.
-```python
-base_q.facets(facets=Facet(name="Organism Names Count", aggregation_type="cardinality", attribute="rcsb_entity_source_organism.ncbi_scientific_name"))
-```
-
-#### Multidimensional Facets
-Complex, multi-dimensional aggregations are possible by specifying additional facets in the `nested_facets` parameter, as in the example below:
-```python
-f1 = Facet(name="Polymer Entity Types", aggregation_type="terms", attribute="rcsb_entry_info.selected_polymer_entity_types")
-f2 = Facet(name="Release Date", aggregation_type="date_histogram", attribute="rcsb_accession_info.initial_release_date", interval="year")
-base_q.facets(facets=Facet(name="Experimental Method", aggregation_type="terms", attribute="rcsb_entry_info.experimental_method", nested_facets=[f1, f2]))
-```
-
-#### Filter Facets
-Filters allow us to filter documents that contribute to bucket count. Similar to queries, we can group several `TerminalFilter`s into a single `GroupFilter`. We can combine a filter with a facet using the `FilterFacet` class. Terminal filters should specify an `attribute` and `operator`, as well as possible a `value` and whether or not it should be a `negation` and/or `case_sensitive`. Group filters should specify a `logical_operator` (which should be either `"and"` or `"or"`) and a list of filters (`nodes`) that should be combined. Finally, the `FilterFacet` should be provided with a filter and a (list of) facet(s). Here are some examples:
-```python
-from rcsbsearchapi.search import TerminalFilter, GroupFilter, FilterFacet
-tf1 = TerminalFilter(attribute="rcsb_polymer_instance_annotation.type", operator="exact_match", value="CATH")
-tf2 = TerminalFilter(attribute="rcsb_polymer_instance_annotation.annotation_lineage.id", operator="in", value=["2.140.10.30", "2.120.10.80"])
-ff2 = FilterFacet(filters=tf2, facets=Facet("CATH Domains", "terms", "rcsb_polymer_instance_annotation.annotation_lineage.id", min_interval_population=1))
-ff1 = FilterFacet(filters=tf1, facets=ff2)
-base_q.facets("polymer_instance", ff1)
-
-tf1 = TerminalFilter(attribute="rcsb_struct_symmetry.kind", operator="exact_match", value="Global Symmetry", negation=False)
-f2 = Facet(name="ec_terms", aggregation_type="terms", attribute="rcsb_polymer_entity.rcsb_ec_lineage.id")
-f1 = Facet(name="sym_symbol_terms", aggregation_type="terms", attribute="rcsb_struct_symmetry.symbol", nested_facets=f2)
-ff = FilterFacet(filters=tf1, facets=f1)
-q1 = AttributeQuery("rcsb_assembly_info.polymer_entity_count", operator="equals", value=1)
-q2 = AttributeQuery("rcsb_assembly_info.polymer_entity_instance_count", operator="greater", value=1)
-q = q1 & q2
-q.facets("assembly", ff)
-
-tf1 = TerminalFilter(attribute="rcsb_polymer_entity_group_membership.aggregation_method", operator="exact_match", value="sequence_identity")
-tf2 = TerminalFilter(attribute="rcsb_polymer_entity_group_membership.similarity_cutoff", operator="equals", value=100)
-gf = GroupFilter(logical_operator="and", nodes=[tf1, tf2])
-ff = FilterFacet(filters=gf, facets=Facet("Distinct Protein Sequence Count", "cardinality", "rcsb_polymer_entity_group_membership.group_id"))
-base_q.facets("polymer_entity", ff)
-```
+An additional example including a Covid-19 related example is in [notebooks/covid.ipynb](notebooks/covid.ipynb):
+<a href="https://colab.research.google.com/github//rcsb/py-rcsbsearchapi/blob/master/notebooks/covid.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>

--- a/rcsbsearchapi/__init__.py
+++ b/rcsbsearchapi/__init__.py
@@ -1,17 +1,8 @@
 """RCSB PDB Search API"""
 
-<<<<<<< HEAD
 from typing import List
 from .search import Terminal, SCHEMA  # noqa: F401
-from .search import Attr, AttributeQuery, Group, Query, Session, TextQuery, Value
-=======
-from typing import TYPE_CHECKING, Any, List
-
-from .schema import Schema
-from .search import Terminal, SCHEMA  # noqa: F401
-from .search import Attr, AttrLeaf, AttributeQuery, Group, Query, Session, TextQuery, Value
-from typing import TYPE_CHECKING
->>>>>>> 5a493e6 (documentation edits and adding page for attribute methods)
+from .search import Attr, AttributeQuery, Group, Query, TextQuery
 
 __version__ = "1.6.0"
 

--- a/rcsbsearchapi/__init__.py
+++ b/rcsbsearchapi/__init__.py
@@ -1,6 +1,6 @@
 """RCSB PDB Search API"""
 
-# from typing import TYPE_CHECKING, Any, List
+from typing import TYPE_CHECKING, Any, List
 
 from .schema import Schema
 from .search import Terminal  # noqa: F401
@@ -21,8 +21,9 @@ rcsb_attributes = SCHEMA.rcsb_attributes
 # if "rcsb_attributes" not in globals():
 #     globals()["rcsb_attributes"] = s.rcsb_attrs
 
+
 # def __dir__() -> List[str]:
-#     print("IN DIR")
 #     return sorted(__all__)
 
-__all__ = ["Query", "Group", "Attr", "Terminal", "TextQuery", "rcsb_attributes"]
+
+__all__ = ["Query", "Group", "Attr", "Terminal", "TextQuery", "AttributeQuery", "rcsb_attributes"]

--- a/rcsbsearchapi/__init__.py
+++ b/rcsbsearchapi/__init__.py
@@ -1,14 +1,17 @@
 """RCSB PDB Search API"""
+
 # from typing import TYPE_CHECKING, Any, List
 
 from .schema import Schema
 from .search import Terminal  # noqa: F401
-from .search import Attr, AttrLeaf, Group, Query, Session, TextQuery, Value
+from .search import Attr, AttrLeaf, AttributeQuery, Group, Query, Session, TextQuery, Value
+from typing import TYPE_CHECKING
 
 __version__ = "1.6.0"
 
 # loading rcsb_attributes can cause errors, so load it lazily
-# if TYPE_CHECKING:
+if TYPE_CHECKING:
+    from .schema import SchemaGroup
 
 SCHEMA = Schema(Attr, "SchemaGroup")
 rcsb_attributes = SCHEMA.rcsb_attributes
@@ -22,20 +25,4 @@ rcsb_attributes = SCHEMA.rcsb_attributes
 #     print("IN DIR")
 #     return sorted(__all__)
 
-__all__ = [
-    "Query",
-    "Group",
-    "Terminal",
-    "TextQuery",
-    "Session",
-    "Attr",
-    "AttrLeaf",
-    "Value",
-    "Schema"
-    # "SCHEMA"
-    # "STRUCTURE_ATTRIBUTE_SCHEMA_URL",
-    # "SEARCH_SCHEMA_URL",
-    # "CHEMICAL_ATTRIBUTE_SCHEMA_URL",
-    # "rcsb_attributes",
-    # "SchemaGroup",
-]
+__all__ = ["Query", "Group", "Attr", "Terminal", "TextQuery", "rcsb_attributes"]

--- a/rcsbsearchapi/__init__.py
+++ b/rcsbsearchapi/__init__.py
@@ -3,7 +3,7 @@
 from typing import TYPE_CHECKING, Any, List
 
 from .schema import Schema
-from .search import Terminal  # noqa: F401
+from .search import Terminal, SCHEMA  # noqa: F401
 from .search import Attr, AttrLeaf, AttributeQuery, Group, Query, Session, TextQuery, Value
 from typing import TYPE_CHECKING
 
@@ -13,7 +13,6 @@ __version__ = "1.6.0"
 if TYPE_CHECKING:
     from .schema import SchemaGroup
 
-SCHEMA = Schema(Attr, "SchemaGroup")
 rcsb_attributes = SCHEMA.rcsb_attributes
 # SCHEMA_DICT = Schema(AttrLeaf, "dict")
 # rcsb_attributes_dict = SCHEMA_DICT.rcsb_attributes_dict
@@ -22,8 +21,16 @@ rcsb_attributes = SCHEMA.rcsb_attributes
 #     globals()["rcsb_attributes"] = s.rcsb_attrs
 
 
-# def __dir__() -> List[str]:
-#     return sorted(__all__)
+def __dir__() -> List[str]:
+    return sorted(__all__)
 
 
-__all__ = ["Query", "Group", "Attr", "Terminal", "TextQuery", "AttributeQuery", "rcsb_attributes"]
+__all__ = [
+    "Query",
+    "Group",
+    "Attr",
+    "Terminal",
+    "TextQuery",
+    "AttributeQuery",
+    "rcsb_attributes"
+]

--- a/rcsbsearchapi/__init__.py
+++ b/rcsbsearchapi/__init__.py
@@ -1,8 +1,17 @@
 """RCSB PDB Search API"""
 
+<<<<<<< HEAD
 from typing import List
 from .search import Terminal, SCHEMA  # noqa: F401
 from .search import Attr, AttributeQuery, Group, Query, Session, TextQuery, Value
+=======
+from typing import TYPE_CHECKING, Any, List
+
+from .schema import Schema
+from .search import Terminal, SCHEMA  # noqa: F401
+from .search import Attr, AttrLeaf, AttributeQuery, Group, Query, Session, TextQuery, Value
+from typing import TYPE_CHECKING
+>>>>>>> 5a493e6 (documentation edits and adding page for attribute methods)
 
 __version__ = "1.6.0"
 

--- a/rcsbsearchapi/__init__.py
+++ b/rcsbsearchapi/__init__.py
@@ -1,17 +1,14 @@
 """RCSB PDB Search API"""
 
-from typing import TYPE_CHECKING, Any, List
-
-from .schema import Schema
+from typing import List
 from .search import Terminal, SCHEMA  # noqa: F401
-from .search import Attr, AttrLeaf, AttributeQuery, Group, Query, Session, TextQuery, Value
-from typing import TYPE_CHECKING
+from .search import Attr, AttributeQuery, Group, Query, Session, TextQuery, Value
 
 __version__ = "1.6.0"
 
-# loading rcsb_attributes can cause errors, so load it lazily
-if TYPE_CHECKING:
-    from .schema import SchemaGroup
+# # loading rcsb_attributes can cause errors, so load it lazily
+# if TYPE_CHECKING:
+#     from .schema import SchemaGroup
 
 rcsb_attributes = SCHEMA.rcsb_attributes
 # SCHEMA_DICT = Schema(AttrLeaf, "dict")

--- a/rcsbsearchapi/schema.py
+++ b/rcsbsearchapi/schema.py
@@ -27,7 +27,7 @@ class SchemaGroup:
         self.Attr = attr_type  # Attr or AttrLeaf
         self._members = {}  # Dictionary to store members
 
-    def search(self, pattern: Union[str, re.Pattern], flags=0):  # TODO: check that this still works
+    def search(self, pattern: Union[str, re.Pattern], flags=0):
         """Find all attributes in the schema matching a regular expression.
 
         Returns:

--- a/rcsbsearchapi/schema.py
+++ b/rcsbsearchapi/schema.py
@@ -44,7 +44,7 @@ class SchemaGroup:
             name = attr_dict["attribute"]
             all_list.append(name)
         return all_list
-    
+
     def __iter__(self):
         """Iterate over all leaf nodes
 
@@ -92,7 +92,7 @@ class SchemaGroup:
             if level not in ptr:
                 warnings.warn(f"Attribute path segment '{level}' (for input '{attribute}') not found in schema.", UserWarning)
                 return None
-            ptr = ptr[level] 
+            ptr = ptr[level]
         if "attribute" in ptr.__dict__ and getattr(ptr, "attribute") == attribute:  # must be .__dict__ so both SchemaGroup and Attr are compared as dictionaries
             return ptr
         else:

--- a/rcsbsearchapi/search.py
+++ b/rcsbsearchapi/search.py
@@ -998,6 +998,7 @@ def _attr_delegate(attr_func: FTerminal) -> Callable[[FQuery], FQuery]:
 
     return decorator
 
+
 class PartialQuery:
     """A PartialQuery extends a growing query with an Attr. It is constructed
     using the fluent syntax with the `and_` and `or_` methods. It is not usually

--- a/rcsbsearchapi/search.py
+++ b/rcsbsearchapi/search.py
@@ -237,10 +237,12 @@ class Query(ABC):
         return response["facets"] if response else []
 
     @overload
-    def and_(self, other: "Query") -> "Query": ...
+    def and_(self, other: "Query") -> "Query":
+        ...
 
     @overload
-    def and_(self, other: Union[str, "Attr"]) -> "PartialQuery": ...
+    def and_(self, other: Union[str, "Attr"]) -> "PartialQuery":
+        ...
 
     def and_(self, other: Union[str, "Query", "Attr"], qtype=STRUCTURE_ATTRIBUTE_SEARCH_SERVICE) -> Union["Query", "PartialQuery"]:
         """Extend this query with an additional attribute via an AND"""
@@ -254,10 +256,12 @@ class Query(ABC):
             raise TypeError(f"Expected Query or Attr, got {type(other)}")
 
     @overload
-    def or_(self, other: "Query") -> "Query": ...
+    def or_(self, other: "Query") -> "Query":
+        ...
 
     @overload
-    def or_(self, other: Union[str, "Attr"]) -> "PartialQuery": ...
+    def or_(self, other: Union[str, "Attr"]) -> "PartialQuery":
+        ...
 
     def or_(self, other: Union[str, "Query", "Attr"], qtype=STRUCTURE_ATTRIBUTE_SEARCH_SERVICE) -> Union["Query", "PartialQuery"]:
         """Extend this query with an additional attribute via an OR"""
@@ -472,7 +476,8 @@ class Attr:
     # Need ignore[override] because typeshed restricts __eq__ return value
     # https://github.com/python/mypy/issues/2783
     @overload  # type: ignore[override]
-    def __eq__(self, value: "Attr") -> bool: ...
+    def __eq__(self, value: "Attr") -> bool:
+        ...
 
     @overload  # type: ignore[override]
     def __eq__(
@@ -487,7 +492,8 @@ class Attr:
             "Value[float]",
             "Value[date]",
         ],
-    ) -> Terminal: ...
+    ) -> Terminal:
+        ...
 
     def __eq__(
         self,
@@ -515,7 +521,8 @@ class Attr:
             return NotImplemented
 
     @overload  # type: ignore[override]
-    def __ne__(self, value: "Attr") -> bool: ...
+    def __ne__(self, value: "Attr") -> bool:
+        ...
 
     @overload  # type: ignore[override]
     def __ne__(
@@ -530,7 +537,8 @@ class Attr:
             "Value[float]",
             "Value[date]",
         ],
-    ) -> Terminal: ...
+    ) -> Terminal:
+        ...
 
     def __ne__(
         self,
@@ -592,6 +600,7 @@ class Attr:
         else:
             return self.contains_phrase(value)
 
+
 @dataclass(frozen=True)
 class AttrLeaf:
     attribute: str
@@ -645,7 +654,7 @@ class AttributeQuery(Terminal):
             negation: logical not
         """
         paramsD = {"attribute": attribute, "operator": operator, "negation": negation}
-        #
+        
         if value is not None:
             paramsD.update({"value": value})
         if not service:
@@ -656,8 +665,8 @@ class AttributeQuery(Terminal):
             for serv in service:
                 error_msg += f'  AttributeQuery(attribute="{attribute}", operator="{operator}", value="{value}", service="{serv}")\n'
             raise ValueError(
-                f'"{attribute}" is in both structure and chemical attributes. Construct an AttributeQuery and specify search service.\n' +
-                f"{error_msg}"
+                f'"{attribute}" is in both structure and chemical attributes. Construct an AttributeQuery and specify search service.\n'
+                + f"{error_msg}"
             )
         assert isinstance(service, str)
         super().__init__(params=paramsD, service=service)
@@ -989,6 +998,7 @@ def _attr_delegate(attr_func: FTerminal) -> Callable[[FQuery], FQuery]:
 
     return decorator
 
+
 class PartialQuery:
     """A PartialQuery extends a growing query with an Attr. It is constructed
     using the fluent syntax with the `and_` and `or_` methods. It is not usually
@@ -1007,34 +1017,44 @@ class PartialQuery:
         self.attr = attr
 
     @_attr_delegate(Attr.exact_match)
-    def exact_match(self, value: Union[str, "Value[str]"]) -> Query: ...
+    def exact_match(self, value: Union[str, "Value[str]"]) -> Query:
+        ...
 
     @_attr_delegate(Attr.contains_words)
-    def contains_words(self, value: Union[str, "Value[str]", List[str], "Value[List[str]]"]) -> Query: ...
+    def contains_words(self, value: Union[str, "Value[str]", List[str], "Value[List[str]]"]) -> Query:
+        ...
 
     @_attr_delegate(Attr.contains_phrase)
-    def contains_phrase(self, value: Union[str, "Value[str]"]) -> Query: ...
+    def contains_phrase(self, value: Union[str, "Value[str]"]) -> Query:
+        ...
 
     @_attr_delegate(Attr.greater)
-    def greater(self, value: TNumberLike) -> Query: ...
+    def greater(self, value: TNumberLike) -> Query:
+        ...
 
     @_attr_delegate(Attr.less)
-    def less(self, value: TNumberLike) -> Query: ...
+    def less(self, value: TNumberLike) -> Query:
+        ...
 
     @_attr_delegate(Attr.greater_or_equal)
-    def greater_or_equal(self, value: TNumberLike) -> Query: ...
+    def greater_or_equal(self, value: TNumberLike) -> Query:
+        ...
 
     @_attr_delegate(Attr.less_or_equal)
-    def less_or_equal(self, value: TNumberLike) -> Query: ...
+    def less_or_equal(self, value: TNumberLike) -> Query:
+        ...
 
     @_attr_delegate(Attr.equals)
-    def equals(self, value: TNumberLike) -> Query: ...
+    def equals(self, value: TNumberLike) -> Query:
+        ...
 
     @_attr_delegate(Attr.range)
-    def range(self, value: Dict[str, Any]) -> Query: ...
+    def range(self, value: Dict[str, Any]) -> Query:
+        ...
 
     @_attr_delegate(Attr.exists)
-    def exists(self) -> Query: ...
+    def exists(self) -> Query:
+        ...
 
     @_attr_delegate(Attr.in_)
     def in_(
@@ -1049,10 +1069,12 @@ class PartialQuery:
             "Value[float]",
             "Value[date]",
         ],
-    ) -> Query: ...
+    ) -> Query:
+        ...
 
     @overload  # type: ignore[override]
-    def __eq__(self, value: "PartialQuery") -> bool: ...
+    def __eq__(self, value: "PartialQuery") -> bool:
+        ...
 
     @overload  # type: ignore[override]
     def __eq__(
@@ -1094,7 +1116,8 @@ class PartialQuery:
             raise ValueError(f"Unknown operator: {self.operator}")
 
     @overload  # type: ignore[override]
-    def __ne__(self, value: "PartialQuery") -> bool: ...
+    def __ne__(self, value: "PartialQuery") -> bool:
+        ...
 
     @overload  # type: ignore[override]
     def __ne__(
@@ -1109,7 +1132,8 @@ class PartialQuery:
             "Value[float]",
             "Value[date]",
         ],
-    ) -> Query: ...
+    ) -> Query:
+        ...
 
     def __ne__(
         self,
@@ -1130,22 +1154,28 @@ class PartialQuery:
         return ~(self == value)
 
     @_attr_delegate(Attr.__lt__)
-    def __lt__(self, value: TNumberLike) -> Query: ...
+    def __lt__(self, value: TNumberLike) -> Query:
+        ...
 
     @_attr_delegate(Attr.__le__)
-    def __le__(self, value: TNumberLike) -> Query: ...
+    def __le__(self, value: TNumberLike) -> Query:
+        ...
 
     @_attr_delegate(Attr.__gt__)
-    def __gt__(self, value: TNumberLike) -> Query: ...
+    def __gt__(self, value: TNumberLike) -> Query:
+        ...
 
     @_attr_delegate(Attr.__ge__)
-    def __ge__(self, value: TNumberLike) -> Query: ...
+    def __ge__(self, value: TNumberLike) -> Query:
+        ...
 
     @_attr_delegate(Attr.__bool__)
-    def __bool__(self) -> Query: ...
+    def __bool__(self) -> Query:
+        ...
 
     @_attr_delegate(Attr.__contains__)
-    def __contains__(self, value: Union[str, List[str], "Value[str]", "Value[List[str]]"]) -> Query: ...
+    def __contains__(self, value: Union[str, List[str], "Value[str]", "Value[List[str]]"]) -> Query:
+        ...
 
 
 T = TypeVar("T", bound="TValue")
@@ -1166,10 +1196,12 @@ class Value(Generic[T]):
     value: T
 
     @overload  # type: ignore[override]
-    def __eq__(self, attr: "Value") -> bool: ...
+    def __eq__(self, attr: "Value") -> bool:
+        ...
 
     @overload  # type: ignore[override]
-    def __eq__(self, attr: Attr) -> Terminal: ...
+    def __eq__(self, attr: Attr) -> Terminal:
+        ...
 
     def __eq__(self, attr: Union["Value", Attr]) -> Union[bool, Terminal]:
         # type: ignore[override]
@@ -1180,10 +1212,12 @@ class Value(Generic[T]):
         return attr == self
 
     @overload  # type: ignore[override]
-    def __ne__(self, attr: "Value") -> bool: ...
+    def __ne__(self, attr: "Value") -> bool:
+        ...
 
     @overload  # type: ignore[override]
-    def __ne__(self, attr: Attr) -> Terminal: ...
+    def __ne__(self, attr: Attr) -> Terminal:
+        ...
 
     def __ne__(self, attr: Union["Value", Attr]) -> Union[bool, Terminal]:
         # type: ignore[override]

--- a/rcsbsearchapi/search.py
+++ b/rcsbsearchapi/search.py
@@ -998,7 +998,6 @@ def _attr_delegate(attr_func: FTerminal) -> Callable[[FQuery], FQuery]:
 
     return decorator
 
-
 class PartialQuery:
     """A PartialQuery extends a growing query with an Attr. It is constructed
     using the fluent syntax with the `and_` and `or_` methods. It is not usually

--- a/rcsbsearchapi/search.py
+++ b/rcsbsearchapi/search.py
@@ -130,6 +130,12 @@ class AttrLeaf:
     type: Union[str, List]
     description: Union[str, List]
 
+    def get_type(self) -> Union[str, List]:
+        return self.type
+
+    def get_description(self) -> str:
+        return self.description
+
     def __contains__(self, key):
         return key in self.__dict__
 
@@ -139,7 +145,7 @@ class AttrLeaf:
         raise KeyError(f"'{key}' not found in object")
 
 
-SCHEMA_DICT = Schema(AttrLeaf, "dict")
+SCHEMA_DICT = Schema(AttrLeaf, "SchemaGroup")
 
 
 def fileUpload(filepath: str, fmt: str = "cif") -> str:
@@ -307,7 +313,7 @@ class Terminal(Query):
         >>> Terminal("text", {"attribute": "rcsb_id", "operator": "in", "negation": False, "value": ["5T89, "1TIM"]})
     """
 
-    service: str
+    service: Union[List, str]
     params: Dict[str, Any]
     node_id: int = 0
 
@@ -383,11 +389,13 @@ class AttributeQuery(Terminal):
         if value is not None:
             paramsD.update({"value": value})
         if not service:
-            service = SCHEMA_DICT.get_attribute_type(attribute)
+            service = SCHEMA_DICT.rcsb_attributes.get_attribute_type(attribute)
 
-            if isinstance(service, list):
-                raise ValueError(f'{attribute} is in both structure and chemical attributes. Run again using one of the following in the "service" argument: {service}')
-        #
+            # TODO: AttributeQuery() specific error msg
+
+        if isinstance(service, list):
+            raise ValueError(f'{attribute} is in both structure and chemical attributes. Run again using one of the following in the "service" argument: {service}')
+
         super().__init__(params=paramsD, service=service)
 
 
@@ -732,7 +740,14 @@ class Attr:
     """
 
     attribute: str
-    type: str  # POSSIBLY BIG CHANGE -- was STRUCTURE_ATTRIBUTE_SEARCH_SERVICE
+    type: Union[List, str]  # POSSIBLY BIG CHANGE -- was STRUCTURE_ATTRIBUTE_SEARCH_SERVICE
+    description: str
+
+    def get_type(self) -> Union[str, List]:
+        return self.type
+
+    def get_description(self) -> str:
+        return self.description
 
     def exact_match(self, value: Union[str, "Value[str]"]) -> AttributeQuery:
         """Exact match with the value"""

--- a/rcsbsearchapi/search.py
+++ b/rcsbsearchapi/search.py
@@ -654,7 +654,7 @@ class AttributeQuery(Terminal):
             negation: logical not
         """
         paramsD = {"attribute": attribute, "operator": operator, "negation": negation}
-        
+
         if value is not None:
             paramsD.update({"value": value})
         if not service:
@@ -1089,7 +1089,8 @@ class PartialQuery:
             "Value[float]",
             "Value[date]",
         ],
-    ) -> Query: ...
+    ) -> Query:
+        ...
 
     def __eq__(
         self,

--- a/rcsbsearchapi/update_schema.py
+++ b/rcsbsearchapi/update_schema.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 
 try:
-    from .schema import _fetch_schema
+    from .search import SCHEMA  # instance of Schema
 except Exception:
     # ignore errors that may occur parsing the schema
     pass
@@ -13,5 +13,5 @@ if __name__ == "__main__":
     path = Path(__file__).parent.joinpath("resources", "metadata_schema.json")
     print(path)
     with open(path, "wt", encoding="utf-8") as file:
-        latest = _fetch_schema("this will be replaced with the URL once this file is in use. ")
+        latest = SCHEMA._fetch_schema("this will be replaced with the URL once this file is in use. ")
         json.dump(latest, file)

--- a/tests/testschema.py
+++ b/tests/testschema.py
@@ -25,8 +25,6 @@ import unittest
 
 from rcsbsearchapi import rcsb_attributes as attrs
 from rcsbsearchapi import SCHEMA
-from rcsbsearchapi.schema import Schema, SchemaGroup
-from rcsbsearchapi.search import Attr, AttrLeaf
 from rcsbsearchapi.const import STRUCTURE_ATTRIBUTE_SCHEMA_URL, CHEMICAL_ATTRIBUTE_SCHEMA_URL, STRUCTURE_ATTRIBUTE_SCHEMA_FILE, CHEMICAL_ATTRIBUTE_SCHEMA_FILE
 
 
@@ -106,7 +104,7 @@ class SchemaTests(unittest.TestCase):
                 attr_dict = vars(attr)
                 desc = attr_dict["description"]
                 self.assertIsNotNone(desc)
-        
+
         with self.subTest(msg="2. Check searching for attribute details"):
             attr_details = attrs.get_attribute_details("drugbank_info.drug_groups")
             for obj_attr in ["attribute", "type", "description"]:

--- a/tests/testschema.py
+++ b/tests/testschema.py
@@ -24,8 +24,10 @@ import time
 import unittest
 
 from rcsbsearchapi import rcsb_attributes as attrs
-from rcsbsearchapi.schema import _load_json_schema, _load_chem_schema, _fetch_schema
-from rcsbsearchapi.const import STRUCTURE_ATTRIBUTE_SCHEMA_URL, CHEMICAL_ATTRIBUTE_SCHEMA_URL
+from rcsbsearchapi import SCHEMA
+from rcsbsearchapi.schema import Schema, SchemaGroup
+from rcsbsearchapi.search import Attr, AttrLeaf
+from rcsbsearchapi.const import STRUCTURE_ATTRIBUTE_SCHEMA_URL, CHEMICAL_ATTRIBUTE_SCHEMA_URL, STRUCTURE_ATTRIBUTE_SCHEMA_FILE, CHEMICAL_ATTRIBUTE_SCHEMA_FILE
 
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s]-%(module)s.%(funcName)s: %(message)s")
@@ -54,8 +56,8 @@ class SchemaTests(unittest.TestCase):
 
     def testSchemaVersion(self):
         # Check structure attribute schema version
-        webSchema = _fetch_schema(STRUCTURE_ATTRIBUTE_SCHEMA_URL)
-        localSchema = _load_json_schema()
+        webSchema = SCHEMA._fetch_schema(STRUCTURE_ATTRIBUTE_SCHEMA_URL)
+        localSchema = SCHEMA._load_json_schema(STRUCTURE_ATTRIBUTE_SCHEMA_FILE)
         webVer = webSchema.get("$comment").split()[-1]
         localVer = localSchema.get("$comment").split()[-1]
         ok = len(localVer.split(".")) == 3 and len(webVer.split(".")) == 3
@@ -68,8 +70,8 @@ class SchemaTests(unittest.TestCase):
         self.assertTrue(ok)
         logger.info("Metadata schema tests results: local version (%r) and web version (%s)", localVer, webVer)
         # Check chemical attribute schema version
-        webSchema = _fetch_schema(CHEMICAL_ATTRIBUTE_SCHEMA_URL)
-        localSchema = _load_chem_schema()
+        webSchema = SCHEMA._fetch_schema(CHEMICAL_ATTRIBUTE_SCHEMA_URL)
+        localSchema = SCHEMA._load_json_schema(CHEMICAL_ATTRIBUTE_SCHEMA_FILE)
         webVer = webSchema.get("$comment").split()[-1]
         localVer = localSchema.get("$comment").split()[-1]
         ok = len(localVer.split(".")) == 3 and len(webVer.split(".")) == 3
@@ -84,19 +86,39 @@ class SchemaTests(unittest.TestCase):
 
     def testFetchSchema(self):
         # check fetching of structure attribute schema
-        fetchSchema = _fetch_schema(STRUCTURE_ATTRIBUTE_SCHEMA_URL)
+        fetchSchema = SCHEMA._fetch_schema(STRUCTURE_ATTRIBUTE_SCHEMA_URL)
         ok = fetchSchema is not None
         logger.info("ok is %r", ok)
         self.assertTrue(ok)
-        fetchSchema = _fetch_schema(CHEMICAL_ATTRIBUTE_SCHEMA_URL)
+        fetchSchema = SCHEMA._fetch_schema(CHEMICAL_ATTRIBUTE_SCHEMA_URL)
         ok = fetchSchema is not None
         logger.info("ok is %r", ok)
         self.assertTrue(ok)
         errorURL = "https://httpbin.org/status/404"
-        fetchSchema = _fetch_schema(errorURL)
+        fetchSchema = SCHEMA._fetch_schema(errorURL)
         ok = fetchSchema is None
         logger.info("ok is %r", ok)
         self.assertTrue(ok)
+
+    def testRcsbAttrs(self):
+        with self.subTest(msg="1. Check type and descriptions exist for attributes"):
+            for attr in attrs:
+                attr_dict = vars(attr)
+                desc = attr_dict["description"]
+                self.assertIsNotNone(desc)
+        
+        with self.subTest(msg="2. Check searching for attribute details"):
+            attr_details = attrs.get_attribute_details("drugbank_info.drug_groups")
+            for obj_attr in ["attribute", "type", "description"]:
+                self.assertIn(obj_attr, vars(attr_details).keys())
+
+            # special case because rcsb_id is in both structure and chemical attributes
+            attr_dict = vars(attrs.get_attribute_details("rcsb_id"))
+            self.assertIsInstance(attr_dict["type"], list)
+            self.assertIsInstance(attr_dict["description"], list)
+
+            attr_details = attrs.get_attribute_details("foo")
+            self.assertIsNone(attr_details)
 
 
 def buildSchema():
@@ -104,6 +126,7 @@ def buildSchema():
     suiteSelect.addTest(SchemaTests("testSchema"))
     suiteSelect.addTest(SchemaTests("testSchemaVersion"))
     suiteSelect.addTest(SchemaTests("testFetchSchema"))
+    suiteSelect.addTest(SchemaTests("testRcsbAttrs"))
 
     return suiteSelect
 

--- a/tests/testsearch.py
+++ b/tests/testsearch.py
@@ -305,7 +305,7 @@ class SearchTests(unittest.TestCase):
 
     def testPartialQuery(self):
         """Test the ability to perform partial queries. """
-        query = Attr(attribute="a", type="text").equals("aval").and_("b")  # TODO: check this is ok
+        query = Attr(attribute="a", type="text").equals("aval").and_("b")
 
         ok = isinstance(query, PartialQuery)
         self.assertTrue(ok)

--- a/tests/testsearch.py
+++ b/tests/testsearch.py
@@ -26,9 +26,10 @@ import os
 from itertools import islice
 import requests
 from rcsbsearchapi.const import CHEMICAL_ATTRIBUTE_SEARCH_SERVICE, STRUCTURE_ATTRIBUTE_SEARCH_SERVICE, RETURN_UP_URL
-from rcsbsearchapi import Attr, Group, Session, TextQuery, Value
+from rcsbsearchapi import Attr, Group, TextQuery
 from rcsbsearchapi import rcsb_attributes as attrs
 from rcsbsearchapi.search import PartialQuery, Terminal, AttributeQuery, SequenceQuery, SeqMotifQuery, StructSimilarityQuery, fileUpload, StructureMotifResidue, StructMotifQuery
+from rcsbsearchapi.search import Session, Value
 from rcsbsearchapi.search import ChemSimilarityQuery
 from rcsbsearchapi.search import Facet, Range, TerminalFilter, GroupFilter, FilterFacet
 

--- a/tests/testsearch.py
+++ b/tests/testsearch.py
@@ -200,7 +200,7 @@ class SearchTests(unittest.TestCase):
         """Attempt to make an invalid, malformed query. Upon finding an error,
         catch the error and pass, continuing tests. An exception is only thrown
         if the query somehow completes successfully. """
-        q1 = AttributeQuery("invalid_identifier", operator="exact_match", value="ERROR")
+        q1 = AttributeQuery("invalid_identifier", operator="exact_match", value="ERROR", service="text")
         session = Session(q1)
         try:
             set(session)
@@ -274,7 +274,7 @@ class SearchTests(unittest.TestCase):
 
     def testAttribute(self):
         """Test the attributes - make sure that they are assigned correctly, etc. """
-        attr = Attr("attr", "text")
+        attr = Attr(attribute="attr", type="type")
 
         term = attr == "value"
         ok = isinstance(term, Terminal)
@@ -305,7 +305,7 @@ class SearchTests(unittest.TestCase):
 
     def testPartialQuery(self):
         """Test the ability to perform partial queries. """
-        query = Attr("a").equals("aval").and_("b")
+        query = Attr(attribute="a", type="text").equals("aval").and_("b")  # TODO: check this is ok
 
         ok = isinstance(query, PartialQuery)
         self.assertTrue(ok)
@@ -330,7 +330,7 @@ class SearchTests(unittest.TestCase):
         self.assertTrue(ok)
         ok = query.nodes[1].params.get("value") == "bval"
 
-        query = query.and_(Attr("c") < 5)
+        query = query.and_(Attr("c", "text") < 5)
         ok = len(query.nodes) == 3
         self.assertTrue(ok)
         ok = query.nodes[2].params.get("attribute") == "c"
@@ -344,7 +344,7 @@ class SearchTests(unittest.TestCase):
 
         ok = isinstance(query, PartialQuery)
         self.assertTrue(ok)
-        ok = query.attr == Attr("d")
+        ok = query.attr == Attr("d", "text")
         self.assertTrue(ok)
         ok = query.operator == "or"
         self.assertTrue(ok)
@@ -369,7 +369,7 @@ class SearchTests(unittest.TestCase):
 
     def testOperators(self):
         """Test operators such as contain and in. """
-        q1 = attrs.rcsb_id.in_(["4HHB", "2GS2"])  # test in
+        q1 = attrs.rcsb_entry_container_identifiers.rcsb_id.in_(["4HHB", "2GS2"])  # test in
         results = list(q1())
         ok = len(results) == 2
         logger.info("In search results length: (%d) ok: (%r)", len(results), ok)
@@ -1033,7 +1033,7 @@ class SearchTests(unittest.TestCase):
         logger.info("Counting results of Chemical similarity query: (%d), ok : (%r)", result, ok)
 
         ok = False
-        q9 = AttributeQuery("invalid_identifier", operator="exact_match", value="ERROR")
+        q9 = AttributeQuery("invalid_identifier", operator="exact_match", value="ERROR", service="textx")
         try:
             _ = q9.count()
         except requests.HTTPError:


### PR DESCRIPTION
SchemaGroup
- Removed rcsb_attributes_dict but kept new methods/overloaded other methods to allow SchemaGroup to contain the same information and also be a dictionary
- Added method to return list of all attributes
- Making an AttributeQuery with "rcsb_id" and no search service will throw an error. "attrs.rcsb_id" will also throw an error and say make an AttributeQuery and specify service.

Documentation
- Rewrote README and moved previous README info into readthedocs "Query" page
- Reorganized readthedocs and added a few pages
    - Attribute searching methods
    - Moved Sequence Motif Search, Facets, etc into "Additional Examples" page