### PR TITLE
Add deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+[DEPRECATED] Active at [rcsb-api](https://rcsbapi.readthedocs.io/en/latest/)
+> Please migrate to our new and improved package, [rcsb-api](https://rcsbapi.readthedocs.io/en/latest/), which contains all the same functionalities as rcsbsearchapi and more! New features will only be added to the new rcsb-api package. For more details, see https://github.com/rcsb/py-rcsbsearchapi/issues/51.
+
 ## v2.0.1 (2025-03-25)
 
 - Add deprecation warnings to README and readthedocs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v2.0.1 (2025-03-25)
+
+- Add deprecation warnings to README and readthedocs
+- Raise a deprecation warning upon import
+
 ## v2.0.0 (2024-10-04)
 
 - Changed facets from function to argument during execution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-[DEPRECATED] Active at [rcsb-api](https://rcsbapi.readthedocs.io/en/latest/)
-> Please migrate to our new and improved package, [rcsb-api](https://rcsbapi.readthedocs.io/en/latest/), which contains all the same functionalities as rcsbsearchapi and more! New features will only be added to the new rcsb-api package. For more details, see https://github.com/rcsb/py-rcsbsearchapi/issues/51.
-
 ## v2.0.1 (2025-03-25)
 
 - Add deprecation warnings to README and readthedocs
 - Raise a deprecation warning upon import
+- [DEPRECATED] Active at [rcsb-api](https://rcsbapi.readthedocs.io/en/latest/) 
+  - Please migrate to our new and improved package, [rcsb-api](https://rcsbapi.readthedocs.io/en/latest/), which contains all the same functionalities as rcsbsearchapi and more! New features will only be added to the new rcsb-api package. For more details, see https://github.com/rcsb/py-rcsbsearchapi/issues/51.
+
 
 ## v2.0.0 (2024-10-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Changelog
 
-## v2.0.1 (2025-03-25)
+## v2.0.1 (2025-03-26)
+
+[DEPRECATED] Active at [rcsb-api](https://rcsbapi.readthedocs.io/en/latest/)
+> Please migrate to our new and improved package, [rcsb-api](https://rcsbapi.readthedocs.io/en/latest/), which contains all the same functionalities as rcsbsearchapi and more! New features will only be added to the new rcsb-api package. For more details, see https://github.com/rcsb/py-rcsbsearchapi/issues/51.
 
 - Add deprecation warnings to README and readthedocs
 - Raise a deprecation warning upon import
-- [DEPRECATED] Active at [rcsb-api](https://rcsbapi.readthedocs.io/en/latest/) 
-  - Please migrate to our new and improved package, [rcsb-api](https://rcsbapi.readthedocs.io/en/latest/), which contains all the same functionalities as rcsbsearchapi and more! New features will only be added to the new rcsb-api package. For more details, see https://github.com/rcsb/py-rcsbsearchapi/issues/51.
-
 
 ## v2.0.0 (2024-10-04)
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![Documentation Status](https://readthedocs.org/projects/rcsbsearchapi/badge/?version=latest)](https://rcsbsearchapi.readthedocs.io/en/latest/?badge=latest)
 <a href="https://colab.research.google.com/github/rcsb/py-rcsbsearchapi/blob/master/notebooks/quickstart.ipynb" target="_parent"><img src="https://colab.research.google.com/assets/colab-badge.svg" alt="Open In Colab"/></a>
 
+# ⛔️ [DEPRECATED] Active at [py-rcsb-api](https://github.com/rcsb/py-rcsb-api)
+> Please migrate to our new and improved package, [rcsb-api](https://github.com/rcsb/py-rcsb-api), which contains all the same functionalities as rcsbsearchapi and more! New features will only be added to the new rcsb-api package. For more details, see https://github.com/rcsb/py-rcsbsearchapi/issues/51.
+
 # rcsbsearchapi
 
 Python interface for the RCSB PDB Search API.

--- a/azure-template-publish-job.yml
+++ b/azure-template-publish-job.yml
@@ -12,7 +12,7 @@ jobs:
 - job: ${{ format('publish_{0}_{1}', parameters.tox, parameters.os) }}
   pool:
     ${{ if eq(parameters.os, 'macos') }}:
-      vmImage: 'macOS-latest'
+      vmImage: 'macOS-15'
     ${{ if eq(parameters.os, 'linux') }}:
       vmImage: 'ubuntu-latest'
   dependsOn:

--- a/azure-template-tox-job.yml
+++ b/azure-template-tox-job.yml
@@ -13,7 +13,7 @@ jobs:
   timeoutInMinutes: 0
   pool:
     ${{ if eq(parameters.os, 'macos') }}:
-      vmImage: 'macOS-latest'
+      vmImage: 'macOS-15'
     ${{ if eq(parameters.os, 'linux') }}:
       vmImage: 'ubuntu-latest'
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# ⛔️ [DEPRECATED] Active at [py-rcsb-api](https://rcsbapi.readthedocs.io/en/latest/#)
+# ⛔️ [DEPRECATED] Active at [rcsb-api](https://rcsbapi.readthedocs.io/en/latest/#)
 > Please migrate to our new and improved package, [rcsb-api](https://rcsbapi.readthedocs.io/en/latest/), which contains all the same functionalities as rcsbsearchapi and more! New features will only be added to the new rcsb-api package. For more details, see https://github.com/rcsb/py-rcsbsearchapi/issues/51.
 
 # rcsbsearchapi - Query protein structures from Python

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,6 @@
+# ⛔️ [DEPRECATED] Active at [py-rcsb-api](https://rcsbapi.readthedocs.io/en/latest/#)
+> Please migrate to our new and improved package, [rcsb-api](https://rcsbapi.readthedocs.io/en/latest/), which contains all the same functionalities as rcsbsearchapi and more! New features will only be added to the new rcsb-api package. For more details, see https://github.com/rcsb/py-rcsbsearchapi/issues/51.
+
 # rcsbsearchapi - Query protein structures from Python
 
 The `rcsbsearchapi` package provides a Python interface to the [RCSB PDB Search API](http://search.rcsb.org/). Use it to fetch lists of PDB IDs corresponding to advanced query searches.

--- a/rcsbsearchapi/__init__.py
+++ b/rcsbsearchapi/__init__.py
@@ -3,13 +3,13 @@
 from typing import List
 from .search import Terminal, SCHEMA  # noqa: F401
 from .search import Attr, AttributeQuery, Group, Query, TextQuery
-import warnings
+from warnings import warn
 
 __version__ = "2.0.1"
 
 rcsb_attributes = SCHEMA.rcsb_attributes
 
-warnings.warn(
+warn(
     """Please migrate to the use of our new and improved package, rcsb-api (https://rcsbapi.readthedocs.io/en/latest/),
     which contains all the same functionalities as rcsbsearchapi and more! New features will only be added to the new rcsb-api package.
     For more details, see https://github.com/rcsb/py-rcsbsearchapi/issues/51.""",

--- a/rcsbsearchapi/__init__.py
+++ b/rcsbsearchapi/__init__.py
@@ -3,10 +3,20 @@
 from typing import List
 from .search import Terminal, SCHEMA  # noqa: F401
 from .search import Attr, AttributeQuery, Group, Query, TextQuery
+import warnings
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 rcsb_attributes = SCHEMA.rcsb_attributes
+
+warnings.warn(
+    """Please migrate to the use of our new and improved package, rcsb-api (https://rcsbapi.readthedocs.io/en/latest/),
+    which contains all the same functionalities as rcsbsearchapi and more! New features will only be added to the new rcsb-api package.
+    For more details, see https://github.com/rcsb/py-rcsbsearchapi/issues/51.""",
+    category=DeprecationWarning,
+    # Set stacklevel so the warning returns to the caller of the code
+    stacklevel=2,
+)
 
 
 def __dir__() -> List[str]:


### PR DESCRIPTION
Original PR #52 

Add deprecation warnings to README, readthedocs, and raise a deprecation warning upon import of the package.
  - Note: I changed the link in the README warning to point to our `py-rcsb-api` repo instead because I felt like if they were already on our github, they would want to be at our new repo rather than documentation
  - For the import warning, I referenced [this article](https://dev.to/hckjck/python-deprecation-2mof)

I referenced [this guide](https://gist.github.com/RichardLitt/741cb6f2fd6c75c0c5f51958160853a9) as well and they recommend adding to the github topics and adding a `no-maintenance-intended` badge (Not sure if that is suitable since we will probably support with bug fixes for a while). Feel free to have a look and let me know if there's anything else I should do!